### PR TITLE
feat(editor): add list dropdown to toolbar

### DIFF
--- a/src/components/editor/plugins/toolbar-plugin/toolbar-editor-plugin.tsx
+++ b/src/components/editor/plugins/toolbar-plugin/toolbar-editor-plugin.tsx
@@ -3,6 +3,7 @@ import { REDO_COMMAND, UNDO_COMMAND, FORMAT_TEXT_COMMAND } from 'lexical';
 import {
   BoldIcon,
   CodeIcon,
+  ListIcon,
   UndoIcon,
   RedoIcon,
   TypeIcon,
@@ -32,9 +33,16 @@ import {
 } from '@/components/ui/tooltip';
 import EDITOR_SHORTCUTS from '@/lib/constants/editor-shortcuts';
 import headings from '@/lib/constants/editor-toolbar-headings';
+import lists from '@/lib/constants/editor-toolbar-lists';
 import useEditorToolbarSync from '@/lib/hooks/use-editor-toolbar-sync';
 import useTooltipGroup from '@/lib/hooks/use-tooltip-group';
-import { formatHeading, formatParagraph } from '@/lib/utils/editor-formatters';
+import {
+  formatHeading,
+  formatCheckList,
+  formatParagraph,
+  formatBulletList,
+  formatNumberedList,
+} from '@/lib/utils/editor-formatters';
 
 export default function ToolbarEditorPlugin() {
   const [editor] = useLexicalComposerContext();
@@ -263,6 +271,45 @@ export default function ToolbarEditorPlugin() {
               {EDITOR_SHORTCUTS.NORMAL}
             </span>
           </DropdownMenuItem>
+        </DropdownMenuContent>
+      </DropdownMenu>
+
+      <DropdownMenu>
+        <DropdownMenuTrigger asChild className="w-44 justify-between">
+          <Button size="sm" variant="outline">
+            <ListIcon className="mr-1 h-4 w-4" />
+            {lists.find((l) => {
+              return l.value === toolbarState.blockType;
+            })?.label || 'Insert list'}
+            <ChevronDownIcon className="ml-1 h-3 w-3" />
+          </Button>
+        </DropdownMenuTrigger>
+        <DropdownMenuContent>
+          {lists.map((list) => {
+            return (
+              <DropdownMenuItem
+                key={list.value}
+                className="flex justify-between gap-4"
+                onClick={() => {
+                  if (list.value === 'bullet') {
+                    formatBulletList(editor, toolbarState.blockType);
+                  } else if (list.value === 'number') {
+                    formatNumberedList(editor, toolbarState.blockType);
+                  } else if (list.value === 'check') {
+                    formatCheckList(editor, toolbarState.blockType);
+                  }
+                }}
+              >
+                <div className="flex items-center">
+                  <list.icon className="mr-2 h-4 w-4" />
+                  <span>{list.label}</span>
+                </div>
+                <span className="text-muted-foreground min-w-14 text-xs">
+                  {list.shortcut}
+                </span>
+              </DropdownMenuItem>
+            );
+          })}
         </DropdownMenuContent>
       </DropdownMenu>
     </div>

--- a/src/lib/constants/editor-toolbar-lists.ts
+++ b/src/lib/constants/editor-toolbar-lists.ts
@@ -1,0 +1,32 @@
+import { ListIcon, ListChecksIcon, ListOrderedIcon } from 'lucide-react';
+import type * as React from 'react';
+
+import EDITOR_SHORTCUTS from '@/lib/constants/editor-shortcuts';
+
+const lists: {
+  icon: React.ComponentType<React.SVGProps<SVGSVGElement>>;
+  label: string;
+  shortcut: string;
+  value: 'bullet' | 'number' | 'check';
+}[] = [
+  {
+    icon: ListIcon,
+    label: 'Bullet list',
+    shortcut: EDITOR_SHORTCUTS.BULLET_LIST,
+    value: 'bullet',
+  },
+  {
+    icon: ListOrderedIcon,
+    label: 'Numbered list',
+    shortcut: EDITOR_SHORTCUTS.NUMBERED_LIST,
+    value: 'number',
+  },
+  {
+    icon: ListChecksIcon,
+    label: 'Check list',
+    shortcut: EDITOR_SHORTCUTS.CHECK_LIST,
+    value: 'check',
+  },
+];
+
+export default lists;


### PR DESCRIPTION
Add a new dropdown control to the editor toolbar that allows users to insert and format lists. The dropdown displays the current list type when active and provides quick access to three list formats.

- Add editor-toolbar-lists.ts constants file defining list types with icons and shortcuts
- Integrate list dropdown in toolbar-editor-plugin.tsx next to headings dropdown
- Display current list type (bullet/number/check) when toolbarState.blockType matches
- Use existing formatter utilities (formatBulletList, formatNumberedList, formatCheckList)
- Show keyboard shortcuts for each list type in dropdown menu
- Support bullet lists (⌘+Shift+8), numbered lists (⌘+Shift+7), and check lists (⌘+Shift+9)