### PR TITLE
feat: make chat and sidebar visible by default

### DIFF
--- a/src/components/providers/chat-status-provider.tsx
+++ b/src/components/providers/chat-status-provider.tsx
@@ -17,7 +17,7 @@ export const ChatStatusContext = React.createContext<{
 
 export default function ChatStatusProvider({ children }: { children: React.ReactNode }) {
   const [status, setStatus] = React.useState<ChatStatus>('ready');
-  const [isChatVisible, setIsChatVisible] = React.useState(false);
+  const [isChatVisible, setIsChatVisible] = React.useState(true);
 
   const value = React.useMemo(() => {
     return { isChatVisible, setIsChatVisible, setStatus, status };

--- a/src/components/providers/sidebar-provider.tsx
+++ b/src/components/providers/sidebar-provider.tsx
@@ -27,7 +27,7 @@ export function useSidebar() {
 }
 
 export default function SidebarProvider({ children }: PropsWithChildren) {
-  const [isExpanded, setIsExpanded] = React.useState(false);
+  const [isExpanded, setIsExpanded] = React.useState(true);
   const isMobile = useIsMobile();
 
   React.useEffect(() => {


### PR DESCRIPTION
Initialize UI visibility to true: set isChatVisible to true in ChatStatusProvider and isExpanded to true in SidebarProvider so the chat and sidebar are shown on initial load. This adjusts the default UI state to improve discoverability and reduce extra clicks for users.

@coderabbitai ignore 