### PR TITLE
feat: rename app to smartext

### DIFF
--- a/.mcp.json
+++ b/.mcp.json
@@ -1,7 +1,7 @@
 {
   "mcpServers": {
     "Sentry": {
-      "url": "https://mcp.sentry.dev/mcp/doms-org/textual"
+      "url": "https://mcp.sentry.dev/mcp/doms-org/smartext"
     },
     "next-devtools": {
       "command": "npx",

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -19,7 +19,7 @@ npm run prettier:write   # Auto-format code
 
 ## Architecture Overview
 
-**Textual** is a Next.js 16 application that combines a Lexical rich-text editor with OpenAI's GPT models for AI-powered content editing. The app uses a split-pane interface with a chat sidebar for AI interactions.
+**Smartext** is a Next.js 16 application that combines a Lexical rich-text editor with OpenAI's GPT models for AI-powered content editing. The app uses a split-pane interface with a chat sidebar for AI interactions.
 
 ### Key Technologies
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,6 +1,6 @@
-# Contributing to Textual
+# Contributing to Smartext
 
-Thank you for your interest in contributing to Textual! This document provides guidelines and instructions for contributing.
+Thank you for your interest in contributing to Smartext! This document provides guidelines and instructions for contributing.
 
 ## Code of Conduct
 
@@ -19,8 +19,8 @@ By participating in this project, you agree to maintain a respectful and inclusi
 1. Fork and clone the repository
 
    ```bash
-   git clone https://github.com/domhhv/textual.git
-   cd textual
+   git clone https://github.com/domhhv/smartext.git
+   cd smartext
    ```
 
 2. Install dependencies
@@ -254,4 +254,4 @@ Future: We plan to add automated testing (Vitest, Cypress).
 
 By contributing, you agree that your contributions will be licensed under the MIT License.
 
-Thank you for contributing to Textual!
+Thank you for contributing to Smartext!

--- a/README.md
+++ b/README.md
@@ -1,12 +1,12 @@
-# Textual
+# Smartext
 
-![CodeRabbit Pull Request Reviews](https://img.shields.io/coderabbit/prs/github/domhhv/textual?utm_source=oss&utm_medium=github&utm_campaign=domhhv%2Ftextual&labelColor=171717&color=FF570A&link=https%3A%2F%2Fcoderabbit.ai&label=CodeRabbit+Reviews)
+![CodeRabbit Pull Request Reviews](https://img.shields.io/coderabbit/prs/github/domhhv/smartext?utm_source=oss&utm_medium=github&utm_campaign=domhhv%2Fsmartext&labelColor=171717&color=FF570A&link=https%3A%2F%2Fcoderabbit.ai&label=CodeRabbit+Reviews)
 
 **An AI-powered rich text editor that transforms how you write and edit content.**
 
-Textual combines a professional-grade rich text editor with OpenAI's GPT models to provide intelligent writing assistance. Unlike traditional AI writing tools that generate entire documents, this application focuses on precise, contextual editing within your existing content.
+Smartext combines a professional-grade rich text editor with OpenAI's GPT models to provide intelligent writing assistance. Unlike traditional AI writing tools that generate entire documents, this application focuses on precise, contextual editing within your existing content.
 
-🌐 **[Try it live at textual.chat](https://textual.chat)**
+🌐 **[Try it live at smartext.chat](https://smartext.chat)**
 
 ## ✨ What Makes It Special
 
@@ -39,7 +39,7 @@ Most AI writing tools either:
 - Generate entire documents from scratch (losing your voice and style)
 - Provide generic suggestions that don't understand context
 
-Textual takes a different approach:
+Smartext takes a different approach:
 
 - **Precision Editing**: Make specific changes to exact locations in your text
 - **Contextual Understanding**: AI sees your entire document for better suggestions
@@ -98,8 +98,8 @@ Textual takes a different approach:
 1. **Clone the repository**
 
    ```bash
-   git clone https://github.com/domhhv/textual.git
-   cd textual
+   git clone https://github.com/domhhv/smartext.git
+   cd smartext
    ```
 
 2. **Install dependencies**
@@ -176,14 +176,14 @@ We welcome contributions! This project demonstrates cutting-edge AI integration 
 
 ## 📝 License
 
-MIT License - see [LICENSE](https://github.com/domhhv/textual/blob/main/LICENSE.md) file for details.
+MIT License - see [LICENSE](https://github.com/domhhv/smartext/blob/main/LICENSE.md) file for details.
 
 ## 🐛 Issues
 
-Found a bug or have a feature request? Please [open an issue](https://github.com/domhhv/textual/issues).
+Found a bug or have a feature request? Please [open an issue](https://github.com/domhhv/smartext/issues).
 
 ---
 
-**Textual represents the future of AI-powered writing tools: intelligent, precise, and designed to enhance rather than replace human creativity.**
+**Smartext represents the future of AI-powered writing tools: intelligent, precise, and designed to enhance rather than replace human creativity.**
 
-Visit [textual.chat](https://textual.chat) to experience it yourself.
+Visit [smartext.chat](https://smartext.chat) to experience it yourself.

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -56,7 +56,7 @@ Include the following information:
 
 ### Best Practices for Users
 
-When using Textual:
+When using Smartext:
 
 - Use your own OpenAI API key (BYOK)
 - Don't share API keys or credentials
@@ -74,4 +74,4 @@ When using Textual:
 
 Security updates will be released as soon as possible after vulnerabilities are identified and fixed. Users should keep their installations up to date.
 
-Thank you for helping keep Textual secure!
+Thank you for helping keep Smartext secure!

--- a/WARP.md
+++ b/WARP.md
@@ -37,7 +37,7 @@ The `prebuild` script runs automatically before `build` and executes:
 
 ## Architecture Overview
 
-**Textual** is an AI-powered rich text editor built with Next.js 16 that combines Lexical editor with OpenAI's GPT models for intelligent, contextual content editing. The key innovation is using structured AI tool calling for precise text manipulation rather than full document regeneration.
+**Smartext** is an AI-powered rich text editor built with Next.js 16 that combines Lexical editor with OpenAI's GPT models for intelligent, contextual content editing. The key innovation is using structured AI tool calling for precise text manipulation rather than full document regeneration.
 
 ### Technology Stack
 

--- a/next.config.ts
+++ b/next.config.ts
@@ -10,7 +10,7 @@ const withBundleAnalyzer = analyzer({
 
 export default withSentryConfig(withBundleAnalyzer(nextConfig), {
   org: 'doms-org',
-  project: 'textual',
+  project: 'smartext',
   silent: !process.env.CI,
   tunnelRoute: '/monitoring',
   widenClientFileUpload: true,

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,11 +1,11 @@
 {
-  "name": "textual",
+  "name": "smartext",
   "version": "0.1.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
-      "name": "textual",
+      "name": "smartext",
       "version": "0.1.0",
       "license": "MIT",
       "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,5 +1,5 @@
 {
-  "name": "textual",
+  "name": "smartext",
   "version": "0.1.0",
   "private": true,
   "description": "An AI-powered rich-text editor assistant that helps you write better content.",
@@ -19,13 +19,13 @@
     "posthog",
     "vercel"
   ],
-  "homepage": "https://textual.chat",
+  "homepage": "https://smartext.app",
   "bugs": {
-    "url": "https://github.com/domhhv/textual/issues"
+    "url": "https://github.com/domhhv/smartext/issues"
   },
   "repository": {
     "type": "git",
-    "url": "https://github.com/domhhv/textual.git"
+    "url": "https://github.com/domhhv/smartext.git"
   },
   "license": "MIT",
   "author": "Dominik Hryshaiev <domhryshaiev@gmail.com>",

--- a/src/app/layout.tsx
+++ b/src/app/layout.tsx
@@ -42,7 +42,7 @@ const montserrat = Montserrat({
 
 export const metadata: Metadata = {
   description: 'LLM-powered rich text editor',
-  title: 'Rich Textual Editor',
+  title: 'Rich Smartext Editor',
 };
 
 async function getAuthState() {

--- a/src/components/account/account.tsx
+++ b/src/components/account/account.tsx
@@ -169,7 +169,7 @@ export default function Account({ hasOpenaiApiKey }: AccountProps) {
                 <ul className="list-disc space-y-1 pl-5">
                   <li>For security reasons, API keys are only stored encrypted and cannot be viewed once set</li>
                   <li>To change an existing API key, you will need to set a new key</li>
-                  <li>You can always remove an API key from Textual if you no longer wish to use it</li>
+                  <li>You can always remove an API key from Smartext if you no longer wish to use it</li>
                 </ul>
               </AlertDescription>
             </Alert>

--- a/src/components/chat/chat-header.tsx
+++ b/src/components/chat/chat-header.tsx
@@ -20,7 +20,7 @@ export default function ChatHeader() {
             </Button>
           )}
           <h3 className="sansation-bold hidden scroll-m-20 truncate text-2xl font-semibold tracking-tight text-slate-600 md:block dark:text-slate-300">
-            <span className="border-b border-dashed border-slate-600 dark:border-slate-300">Textual</span> Chat
+            Smartext
           </h3>
         </div>
       </div>

--- a/src/components/layout/development-banner.tsx
+++ b/src/components/layout/development-banner.tsx
@@ -4,7 +4,7 @@ import { useCallback, useSyncExternalStore } from 'react';
 
 import { Button } from '@/components/ui/button';
 
-const STORAGE_KEY = 'textual-dev-banner-dismissed';
+const STORAGE_KEY = 'smartext-dev-banner-dismissed';
 
 function subscribe(callback: () => void) {
   window.addEventListener('storage', callback);

--- a/src/components/layout/sidebar.tsx
+++ b/src/components/layout/sidebar.tsx
@@ -152,7 +152,7 @@ export default function Sidebar({ documents, isAuthenticated, isDocumentsError }
                     </div>
                     <Tooltip delayDuration={tooltipGroup.getTooltipProps().delayDuration}>
                       <TooltipTrigger asChild onMouseEnter={tooltipGroup.getTooltipProps().onMouseEnter}>
-                        <Link target="_blank" rel="noopener noreferrer" href="https://github.com/domhhv/textual">
+                        <Link target="_blank" rel="noopener noreferrer" href="https://github.com/domhhv/smartext">
                           <Button size="xs" variant="outline" className="h-8 w-8">
                             <GithubIcon className="fill-muted-foreground size-4!" />
                           </Button>
@@ -174,7 +174,7 @@ export default function Sidebar({ documents, isAuthenticated, isDocumentsError }
 
         {!isAuthenticated && isExpanded && (
           <div className="p-4">
-            <h3 className="scroll-m-20 text-2xl font-semibold tracking-tight">Welcome to Textual</h3>
+            <h3 className="scroll-m-20 text-2xl font-semibold tracking-tight">Welcome to Smartext</h3>
             <p className="text-muted-foreground mt-2 text-sm">
               Sign in or create an account to start creating and managing your documents.
             </p>

--- a/src/lib/constants/editor-sample-contents.ts
+++ b/src/lib/constants/editor-sample-contents.ts
@@ -331,9 +331,9 @@ Tables organize information into rows and columns, making complex data easy to c
 | Support | ⭐⭐⭐ | ⭐ | ⭐⭐ |
 | **Total** | **9** | **9** | **8** |`;
 
-const everything = `# Welcome to Textual: The Complete Guide
+const everything = `# Welcome to Smartext: The Complete Guide
 
-**Textual** is a _powerful_ AI-assisted rich text editor that combines the elegance of Lexical with the intelligence of OpenAI's GPT. This document showcases every formatting feature available.
+**Smartext** is a _powerful_ AI-assisted rich text editor that combines the elegance of Lexical with the intelligence of OpenAI's GPT. This document showcases every formatting feature available.
 
 ---
 
@@ -540,7 +540,7 @@ This document demonstrates how different formatting elements work together to cr
 3. Project plans with task lists and status tables
 4. Creative content with quotes and emphasis
 
-> Textual adapts to your needs, combining the power of AI with intuitive formatting tools.
+> Smartext adapts to your needs, combining the power of AI with intuitive formatting tools.
 
 ### Quick Reference
 

--- a/supabase/config.toml
+++ b/supabase/config.toml
@@ -2,7 +2,7 @@
 # https://supabase.com/docs/guides/local-development/cli/config
 # A string used to distinguish different Supabase projects on the same host. Defaults to the
 # working directory name when running `supabase init`.
-project_id = "textual"
+project_id = "smartext"
 
 [api]
 enabled = true


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Rebranded project from Textual to Smartext throughout the application, including user-facing UI elements, documentation, and configuration files
  * Updated all repository references, endpoints, project identifiers, and metadata to reflect the new branding infrastructure

<!-- end of auto-generated comment: release notes by coderabbit.ai -->