### PR TITLE
fix(layout): prevent overflow in app panes

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -4,15 +4,15 @@ Brief description of your changes.
 
 ## Type of Change
 
-- [] Bug fix
-- [] New feature
-- [] Documentation update
-- [] Refactoring
-- [] Performance improvement
-- [] Test addition or update
-- [] Build process or tooling change
-- [] Code style or formatting change
-- [] Other (please describe)
+- [ ] Bug fix
+- [ ] New feature
+- [ ] Documentation update
+- [ ] Refactoring
+- [ ] Performance improvement
+- [ ] Test addition or update
+- [ ] Build process or tooling change
+- [ ] Code style or formatting change
+- [ ] Other (please describe)
 
 [//]: # 'Uncomment the following lines if your change is related to an issue'
 [//]: # '## Related Issues (if any)'
@@ -21,6 +21,6 @@ Brief description of your changes.
 
 ## Checklist
 
-- [] My code follows the project's style guidelines
-- [] I've tested my changes locally
-- [] I've updated documentation if needed
+- [ ] My code follows the project's style guidelines
+- [ ] I've tested my changes locally
+- [ ] I've updated documentation if needed

--- a/.github/copilot-instructions.md
+++ b/.github/copilot-instructions.md
@@ -1,0 +1,64 @@
+When generating a commit message, follow the Conventional Commits format. The commit message should be structured as follows:
+
+```text
+<type>[optional scope]: <description>
+
+[optional body]
+```
+
+The type should be one of the following:
+
+```json
+{
+  "types": {
+    "feat": {
+      "description": "A new feature",
+      "title": "Features"
+    },
+    "fix": {
+      "description": "A bug fix",
+      "title": "Bug Fixes"
+    },
+    "docs": {
+      "description": "Documentation only changes",
+      "title": "Documentation"
+    },
+    "style": {
+      "description": "Changes that do not affect the meaning of the code (white-space, formatting, missing semi-colons, etc)",
+      "title": "Styles"
+    },
+    "refactor": {
+      "description": "A code change that neither fixes a bug nor adds a feature",
+      "title": "Code Refactoring"
+    },
+    "perf": {
+      "description": "A code change that improves performance",
+      "title": "Performance Improvements"
+    },
+    "test": {
+      "description": "Adding missing tests or correcting existing tests",
+      "title": "Tests"
+    },
+    "build": {
+      "description": "Changes that affect the build system or external dependencies (example scopes: gulp, broccoli, npm)",
+      "title": "Builds"
+    },
+    "ci": {
+      "description": "Changes to our CI configuration files and scripts (example scopes: Travis, Circle, BrowserStack, SauceLabs)",
+      "title": "Continuous Integrations"
+    },
+    "chore": {
+      "description": "Other changes that don't modify src or test files",
+      "title": "Chores"
+    },
+    "revert": {
+      "description": "Reverts a previous commit",
+      "title": "Reverts"
+    }
+  }
+}
+```
+
+The scope should be the name of the feature affected by the change (e.g. `editor`, `auth`, `ui`, etc.). The scope can also be omitted if the change affects multiple features.
+
+The body should consist of a short description of the change (up to three sentences) and a list of any breaking changes.

--- a/eslint.config.mjs
+++ b/eslint.config.mjs
@@ -155,6 +155,7 @@ export default defineConfig(
     {
       extends: ['markdown/recommended'],
       files: ['**/*.md'],
+      language: 'markdown/gfm',
       plugins: {
         markdown,
       },

--- a/src/app/layout.tsx
+++ b/src/app/layout.tsx
@@ -123,11 +123,11 @@ async function DocumentsProvider({ children }: Readonly<React.PropsWithChildren>
   return (
     <DocumentProvider documents={documents} isAuthenticated={isAuthenticated}>
       <SidebarProvider>
-        <div className="bg-background relative flex h-full flex-col">
+        <div className="bg-background relative flex h-full flex-col overflow-hidden">
           <DevelopmentBanner />
-          <div className="relative flex h-full flex-1">
+          <div className="relative flex min-h-0 flex-1 overflow-hidden">
             <Sidebar documents={documents} isDocumentsError={!!error} isAuthenticated={isAuthenticated} />
-            <main className="flex-1 overflow-scroll">{children}</main>
+            <main className="min-w-0 flex-1 overflow-hidden">{children}</main>
           </div>
           <Analytics />
           <SpeedInsights />

--- a/src/components/chat/chat-prompt-input.tsx
+++ b/src/components/chat/chat-prompt-input.tsx
@@ -29,7 +29,6 @@ import {
   PromptInputAttachment,
   PromptInputAttachments,
   type PromptInputMessage,
-  PromptInputSpeechButton,
   PromptInputActionMenuContent,
   PromptInputActionMenuTrigger,
   PromptInputActionAddAttachments,
@@ -104,7 +103,6 @@ function ChatPromptInput({
                   <PromptInputActionAddAttachments />
                 </PromptInputActionMenuContent>
               </PromptInputActionMenu>
-              <PromptInputSpeechButton textareaRef={textareaRef} />
               <ModelSelector open={modelSelectorOpen} onOpenChange={setModelSelectorOpen}>
                 <ModelSelectorTrigger asChild>
                   <PromptInputButton>

--- a/src/components/editor/editor.tsx
+++ b/src/components/editor/editor.tsx
@@ -73,14 +73,14 @@ export default function Editor() {
   }
 
   return (
-    <div className="editor group relative h-full overflow-y-auto">
+    <div className="editor group relative flex h-full min-h-0 flex-col overflow-hidden">
       <ToolbarPlugin />
       <RichTextPlugin
         ErrorBoundary={LexicalErrorBoundary}
         contentEditable={
           <div
             ref={floatingAnchorRef}
-            className="border-border focus-within:border-foreground group relative h-[calc(100%-52px)] overflow-y-auto border-t px-[1px] pb-[1px] focus-within:border focus-within:px-0 focus-within:pb-0.5"
+            className="border-border focus-within:border-foreground group relative min-h-0 flex-1 overflow-y-auto border-t px-[1px] pb-[1px] focus-within:border focus-within:px-0 focus-within:pb-0.5"
           >
             <ContentEditable
               className="h-fit p-4 outline-none"

--- a/src/components/layout/adaptive-layout.tsx
+++ b/src/components/layout/adaptive-layout.tsx
@@ -79,37 +79,37 @@ export default function AdaptiveLayout({ chat, editor }: AdaptiveLayoutProps) {
 
   if (!isMobile) {
     if (!isChatVisible) {
-      return <div className="h-full">{editor}</div>;
+      return <div className="h-full min-h-0">{editor}</div>;
     }
 
     return (
-      <ResizablePanelGroup className="min-h-full" orientation="horizontal">
-        <ResizablePanel minSize="10%" defaultSize="30%">
-          {chat}
+      <ResizablePanelGroup orientation="horizontal" className="h-full min-h-0">
+        <ResizablePanel minSize="20%" defaultSize="40%">
+          <div className="h-full min-h-0">{chat}</div>
         </ResizablePanel>
         <ResizableHandle isWithHandle />
-        <ResizablePanel minSize="40%" defaultSize="70%">
-          {editor}
+        <ResizablePanel minSize="40%" defaultSize="60%">
+          <div className="h-full min-h-0">{editor}</div>
         </ResizablePanel>
       </ResizablePanelGroup>
     );
   }
 
   if (!isChatVisible) {
-    return <div className="flex h-full flex-col">{editor}</div>;
+    return <div className="flex h-full min-h-0 flex-col">{editor}</div>;
   }
 
   return (
-    <div className="flex h-full flex-col">
+    <div className="flex h-full min-h-0 flex-col">
       <div className="relative flex-1 overflow-hidden">
         {viewMode === 'split' ? (
           <ResizablePanelGroup className="h-full" orientation="vertical">
             <ResizablePanel minSize="45%" defaultSize="50%">
-              {chat}
+              <div className="h-full min-h-0">{chat}</div>
             </ResizablePanel>
             <ResizableHandle isWithHandle />
             <ResizablePanel minSize="30%" defaultSize="50%">
-              {editor}
+              <div className="h-full min-h-0">{editor}</div>
             </ResizablePanel>
           </ResizablePanelGroup>
         ) : (

--- a/src/components/layout/development-banner.tsx
+++ b/src/components/layout/development-banner.tsx
@@ -35,7 +35,7 @@ export default function DevelopmentBanner() {
   }
 
   return (
-    <div className="bg-accent text-foreground sticky top-0 flex w-full flex-wrap items-center justify-center gap-x-4 gap-y-2 px-4 py-2 text-center text-sm font-medium">
+    <div className="bg-accent text-foreground z-20 flex w-full flex-wrap items-center justify-center gap-x-4 gap-y-2 px-4 py-2 text-center text-sm font-medium">
       <span>
         🚧&nbsp;&nbsp;&nbsp;This app is in early development. Some unexpected bugs might occur. New features are coming
         soon!

--- a/src/lib/utils/encryption.ts
+++ b/src/lib/utils/encryption.ts
@@ -4,7 +4,13 @@ import { randomBytes, createCipheriv, createDecipheriv } from 'crypto';
 const ALGORITHM = 'aes-256-gcm';
 const IV_LENGTH_BYTES = 12;
 
+let cachedKey: Buffer | null = null;
+
 function getKey(): Buffer {
+  if (cachedKey) {
+    return cachedKey;
+  }
+
   const secret = process.env.ENCRYPTION_SECRET;
 
   if (!secret) {
@@ -17,7 +23,9 @@ function getKey(): Buffer {
     throw new Error('ENCRYPTION_SECRET must be 32 bytes hex (64 hex chars)');
   }
 
-  return key;
+  cachedKey = key;
+
+  return cachedKey;
 }
 
 export function encryptKey(plaintext: string) {

--- a/src/lib/utils/encryption.ts
+++ b/src/lib/utils/encryption.ts
@@ -1,18 +1,23 @@
 import 'server-only';
 import { randomBytes, createCipheriv, createDecipheriv } from 'crypto';
 
-const SECRET = process.env.ENCRYPTION_SECRET;
 const ALGORITHM = 'aes-256-gcm';
 const IV_LENGTH_BYTES = 12;
 
-if (!SECRET) {
-  throw new Error('ENCRYPTION_SECRET is required');
-}
+function getKey(): Buffer {
+  const secret = process.env.ENCRYPTION_SECRET;
 
-const KEY = Buffer.from(SECRET, 'hex');
+  if (!secret) {
+    throw new Error('ENCRYPTION_SECRET is required');
+  }
 
-if (KEY.length !== 32) {
-  throw new Error('ENCRYPTION_SECRET must be 32 bytes hex (64 hex chars)');
+  const key = Buffer.from(secret, 'hex');
+
+  if (key.length !== 32) {
+    throw new Error('ENCRYPTION_SECRET must be 32 bytes hex (64 hex chars)');
+  }
+
+  return key;
 }
 
 export function encryptKey(plaintext: string) {
@@ -20,8 +25,9 @@ export function encryptKey(plaintext: string) {
     return '';
   }
 
+  const key = getKey();
   const iv = randomBytes(IV_LENGTH_BYTES);
-  const cipher = createCipheriv(ALGORITHM, KEY, iv);
+  const cipher = createCipheriv(ALGORITHM, key, iv);
 
   let encrypted = cipher.update(plaintext, 'utf8', 'hex');
   encrypted += cipher.final('hex');
@@ -45,7 +51,7 @@ export function decryptKey(ciphertext: string) {
   const iv = Buffer.from(ivHex, 'hex');
   const authTag = Buffer.from(authTagHex, 'hex');
 
-  const decipher = createDecipheriv(ALGORITHM, KEY, iv);
+  const decipher = createDecipheriv(ALGORITHM, getKey(), iv);
   decipher.setAuthTag(authTag);
 
   let decrypted = decipher.update(encrypted, 'hex', 'utf8');

--- a/supabase/config.toml
+++ b/supabase/config.toml
@@ -90,7 +90,7 @@ openai_api_key = "env(OPENAI_API_KEY)"
 
 # Email testing server. Emails sent with the local dev setup are not actually sent - rather, they
 # are monitored, and you can view the emails that would have been sent from the web interface.
-[inbucket]
+[local_smtp]
 enabled = true
 # Port to use for the email testing server web interface.
 port = 54324


### PR DESCRIPTION
## Description

Refines the app/editor/chat container structure to use `min-h-0` and overflow-safe wrappers, updates panel sizing defaults, and adjusts the development banner layering so split views scroll and resize correctly. It also removes the prompt speech button, enables GFM parsing for Markdown linting, updates PR template checkboxes formatting, adds Copilot commit guidance, and renames Supabase email testing config from `[inbucket]` to `[local_smtp]`.

@coderabbitai ignore 

## Type of Change

- [] Bug fix
- [] New feature
- [] Documentation update
- [] Refactoring
- [] Performance improvement
- [] Test addition or update
- [] Build process or tooling change
- [] Code style or formatting change
- [] Other (please describe)

[//]: # 'Uncomment the following lines if your change is related to an issue'
[//]: # '## Related Issues (if any)'
[//]: #
[//]: # 'Fixes #(issue number)'

## Checklist

- [] My code follows the project's style guidelines
- [] I've tested my changes locally
- [] I've updated documentation if needed
