### PR TITLE
ci: add first-load js bundle size reporting

### DIFF
--- a/.github/workflows/bundle-first-load.yml
+++ b/.github/workflows/bundle-first-load.yml
@@ -1,0 +1,75 @@
+name: First Load JS Bundle Size per route
+
+on:
+  push:
+    branches:
+      - main
+  pull_request:
+    branches:
+      - main
+
+env:
+  NODE_VERSION: 24.18.0
+
+# Cancel superseded runs on the same ref (e.g. rapid pushes to a PR).
+concurrency:
+  group: bundle-first-load-${{ github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  measure:
+    if: >-
+      github.event_name == 'push' ||
+      !contains(github.event.pull_request.body, '[skip first-load-bundle-size-ci]')
+    name: Measure and report bundle
+    runs-on: ubuntu-latest
+    permissions:
+      contents: write # commit the baseline on push to main
+      pull-requests: write # post the sticky comment on PRs
+    steps:
+      - uses: actions/checkout@v7.0.0
+        with:
+          # Full history so `git show origin/main:bundle-sizes.json` works on PRs.
+          fetch-depth: 0
+
+      - uses: actions/setup-node@v6.4.0
+        with:
+          node-version: ${{ env.NODE_VERSION }}
+          cache: 'npm'
+
+      - name: Install dependencies
+        run: npm ci
+
+      - name: Build (webpack) and measure First Load JS Bundle Size
+        run: |
+          npx next build --webpack
+          npm run bundle:measure
+
+      # ---- Push to main: commit the new baseline ----
+      - name: Commit baseline
+        if: github.event_name == 'push'
+        run: |
+          git add bundle-sizes.json
+          if git diff --cached --quiet -- bundle-sizes.json; then
+            echo "Baseline unchanged."
+            exit 0
+          fi
+          git config user.name "github-actions[bot]"
+          git config user.email "41898282+github-actions[bot]@users.noreply.github.com"
+          git commit -m "chore(ci): update first load js bundle size baseline [skip ci]"
+          git push
+
+      # ---- Pull request: diff against main and comment ----
+      - name: Compare against main baseline
+        if: github.event_name == 'pull_request'
+        run: |
+          git show origin/main:bundle-sizes.json > base-sizes.json 2>/dev/null || echo "" > base-sizes.json
+          npm run bundle:compare -- base-sizes.json bundle-sizes.json > bundle-report.md
+          cat bundle-report.md >> "$GITHUB_STEP_SUMMARY"
+
+      - name: Post sticky PR comment
+        if: github.event_name == 'pull_request'
+        uses: marocchino/sticky-pull-request-comment@v2.9.4
+        with:
+          header: first-load-js
+          path: bundle-report.md

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -101,3 +101,13 @@ The project has comprehensive linting and formatting:
 - **Component Location**: Keep shadcn primitives in `ui/`, custom components that build upon them in `ui/custom/`
 - **File Naming**: Use lowercase with hyphens for files and directories
 - **Types Inference**: Prefer inferred types over explicit annotations where possible
+
+#### Comments
+
+Never add explanatory comments unless absolutely necessary.
+
+Code must be clean, readable, and self-documenting.
+
+If a comment is necessary, use the multi-line comments (block comments) format. JSDoc and TODO comments are allowed.
+
+Never use single-line comments except for ESLint or TypeScript directives.

--- a/bundle-sizes.json
+++ b/bundle-sizes.json
@@ -1,0 +1,34 @@
+{
+  "generatedAt": "2026-07-03T12:48:17.407Z",
+  "routes": {
+    "/_not-found": {
+      "gzip": 843761,
+      "raw": 2677565
+    },
+    "/_global-error": {
+      "gzip": 842942,
+      "raw": 2675059
+    },
+    "/account/[[...account]]": {
+      "gzip": 852964,
+      "raw": 2701849
+    },
+    "/login/[[...login]]": {
+      "gzip": 843123,
+      "raw": 2675447
+    },
+    "/": {
+      "gzip": 1175259,
+      "raw": 3768836
+    },
+    "/register/[[...register]]": {
+      "gzip": 843125,
+      "raw": 2675447
+    }
+  },
+  "unit": "bytes",
+  "shared": {
+    "gzip": 842611,
+    "raw": 2674530
+  }
+}

--- a/next.config.ts
+++ b/next.config.ts
@@ -23,6 +23,15 @@ const nextConfig: NextConfig = {
           },
         })
       );
+      config.plugins.push(
+        new StatsWriterPlugin({
+          filename: '../.next/analyze/entrypoints.json',
+          stats: {
+            all: false,
+            entrypoints: true,
+          },
+        })
+      );
     }
 
     return config;

--- a/package.json
+++ b/package.json
@@ -38,6 +38,8 @@
     "prebuild": "npm run typecheck && npm run eslint:check && npm run prettier:check",
     "build": "TURBOPACK_STATS=1 next build",
     "build:webpack": "next build --webpack",
+    "bundle:compare": "node scripts/compare-bundle.mjs",
+    "bundle:measure": "node scripts/measure-bundle.mjs",
     "db:diff": "supabase db diff",
     "db:diff:storage": "supabase db diff --schema storage",
     "db:gen-types": "supabase gen types --lang=typescript --schema public --schema auth --schema storage --local > supabase/database.types.ts && node scripts/patch-json-type.mjs && eslint --fix supabase/database.types.ts",

--- a/scripts/compare-bundle.mjs
+++ b/scripts/compare-bundle.mjs
@@ -1,0 +1,97 @@
+#!/usr/bin/env node
+// Diffs two bundle-sizes.json reports and prints a Markdown table (gzip First
+// Load JS per route, delta vs base). Used by CI to build the sticky PR comment.
+//
+//   node scripts/compare-bundle.mjs <base.json> <head.json>
+//
+// Missing base file (first run) => reports head as all-new, no failure.
+
+import { readFileSync } from 'node:fs';
+
+const [basePath, headPath] = process.argv.slice(2);
+
+function load(path) {
+  try {
+    return JSON.parse(readFileSync(path, 'utf8'));
+  } catch {
+    return null;
+  }
+}
+
+const base = load(basePath);
+const head = load(headPath);
+
+if (!head) {
+  process.stdout.write('No head bundle-sizes.json found — nothing to report.\n');
+  process.exit(0);
+}
+
+const kib = (n) => {
+  return (n / 1024).toFixed(1);
+};
+
+const signed = (n) => {
+  return n >= 0 ? `+${n}` : `${n}`;
+};
+
+const pct = (from, to) => {
+  return from === 0 ? '—' : `${signed(((to - from) / from) * 100).slice(0, 5)}%`;
+};
+
+const routes = new Set([...Object.keys(base?.routes ?? {}), ...Object.keys(head.routes ?? {})]);
+
+const rows = [];
+let regressed = false;
+
+for (const route of [...routes].sort()) {
+  const b = base?.routes?.[route]?.gzip ?? null;
+  const h = head.routes?.[route]?.gzip ?? null;
+
+  if (h === null) {
+    rows.push(`| \`${route}\` | — | ${kib(b)} | removed |`);
+    continue;
+  }
+
+  if (b === null) {
+    rows.push(`| \`${route}\` | **${kib(h)}** | — | 🆕 new |`);
+    continue;
+  }
+
+  const diff = h - b;
+  const arrow = diff > 0 ? '🔴' : diff < 0 ? '🟢' : '⚪';
+  if (diff > 0) regressed = true;
+  const delta = diff === 0 ? '—' : `${arrow} ${signed(+kib(diff))} KiB (${pct(b, h)})`;
+  rows.push(`| \`${route}\` | **${kib(h)}** | ${kib(b)} | ${delta} |`);
+}
+
+const sharedH = head.shared?.gzip ?? 0;
+const sharedB = base?.shared?.gzip ?? null;
+const sharedDelta =
+  sharedB === null
+    ? '🆕 new'
+    : sharedH === sharedB
+      ? '—'
+      : `${sharedH > sharedB ? '🔴' : '🟢'} ${signed(+kib(sharedH - sharedB))} KiB`;
+
+const lines = [
+  '## 📦 First Load JS per route',
+  '',
+  'Gzipped client JS a fresh visit downloads, by route.',
+  '',
+  '| Route | This PR (KiB) | main (KiB) | Δ |',
+  '|---|---:|---:|---|',
+  ...rows,
+  '',
+  `**Shared baseline:** ${kib(sharedH)} KiB (${sharedDelta}) — loaded on every route.`,
+  '',
+  base ? '' : '_No baseline on main yet — this is the first report._',
+  '<sub>Computed from webpack entrypoints in CI. Raw report: `bundle-sizes.json`.</sub>',
+].filter((l) => {
+  return l !== undefined;
+});
+
+process.stdout.write(lines.join('\n') + '\n');
+
+// Signal a regression via exit code so a workflow *could* gate on it if desired.
+// Default workflow does not fail the job on this.
+if (regressed && process.env.FAIL_ON_REGRESSION === 'true') process.exit(1);

--- a/scripts/measure-bundle.mjs
+++ b/scripts/measure-bundle.mjs
@@ -1,0 +1,119 @@
+#!/usr/bin/env node
+// Computes "First Load JS per route" from the webpack entrypoints emitted by
+// next.config's StatsWriterPlugin, sizing each asset from the built files on disk
+// (raw + gzip). Writes bundle-sizes.json — the raw report consumed by the CI diff.
+//
+// Run after `next build --webpack`.
+
+import { statSync, readFileSync, writeFileSync } from 'node:fs';
+import { join } from 'node:path';
+import { gzipSync } from 'node:zlib';
+
+const DIST = '.next';
+const ENTRYPOINTS = join(DIST, 'analyze', 'entrypoints.json');
+const OUT = 'bundle-sizes.json';
+
+// Entrypoints whose assets every page inherits (App Router shared baseline).
+const SHARED = ['main', 'main-app', 'app/layout'];
+
+const rawCache = new Map();
+const gzCache = new Map();
+
+function rawSize(file) {
+  if (rawCache.has(file)) return rawCache.get(file);
+  let size = 0;
+
+  try {
+    size = statSync(join(DIST, file)).size;
+  } catch {
+    size = 0;
+  }
+
+  rawCache.set(file, size);
+
+  return size;
+}
+
+function gzSize(file) {
+  if (gzCache.has(file)) return gzCache.get(file);
+  let size = 0;
+
+  try {
+    size = gzipSync(readFileSync(join(DIST, file))).length;
+  } catch {
+    size = 0;
+  }
+
+  gzCache.set(file, size);
+
+  return size;
+}
+
+function jsAssets(entrypoint) {
+  const assets = entrypoint?.assets ?? [];
+
+  return assets
+    .map((a) => {
+      return typeof a === 'string' ? a : a.name;
+    })
+    .filter((name) => {
+      return name && name.endsWith('.js');
+    });
+}
+
+function sum(files, sizer) {
+  return [...files].reduce((total, file) => {
+    return total + sizer(file);
+  }, 0);
+}
+
+const stats = JSON.parse(readFileSync(ENTRYPOINTS, 'utf8'));
+const entrypoints = stats.entrypoints ?? {};
+
+const sharedFiles = new Set(
+  SHARED.flatMap((name) => {
+    return jsAssets(entrypoints[name]);
+  })
+);
+
+const routes = Object.keys(entrypoints)
+  .filter((name) => {
+    return name.startsWith('app/') && name.endsWith('/page');
+  })
+  .filter((name) => {
+    return !name.includes('/api/');
+  });
+
+const report = {
+  generatedAt: new Date().toISOString(),
+  routes: {},
+  unit: 'bytes',
+  shared: {
+    gzip: sum(sharedFiles, gzSize),
+    raw: sum(sharedFiles, rawSize),
+  },
+};
+
+for (const name of routes) {
+  const route = name.replace(/^app/, '').replace(/\/page$/, '') || '/';
+  const files = new Set([...sharedFiles, ...jsAssets(entrypoints[name])]);
+  report.routes[route] = {
+    gzip: sum(files, gzSize),
+    raw: sum(files, rawSize),
+  };
+}
+
+writeFileSync(OUT, JSON.stringify(report, null, 2) + '\n');
+
+const kib = (n) => {
+  return (n / 1024).toFixed(1).padStart(9);
+};
+
+process.stdout.write('\nFirst Load JS per route\n\n');
+process.stdout.write('route'.padEnd(30) + 'raw KiB'.padStart(9) + 'gz KiB'.padStart(9) + '\n');
+
+for (const [route, size] of Object.entries(report.routes)) {
+  process.stdout.write(route.padEnd(30) + kib(size.raw) + kib(size.gzip) + '\n');
+}
+
+process.stdout.write(`\nWrote ${OUT}\n`);


### PR DESCRIPTION
## Description

Adds a CI workflow and helper scripts to measure First Load JS per route, write `bundle-sizes.json`, and compare it against the main baseline. Also wires webpack stats output into the build so the report can be generated from CI artifacts.

## Type of Change

- [ ] Bug fix
- [ ] New feature
- [ ] Documentation update
- [ ] Refactoring
- [ ] Performance improvement
- [ ] Test addition or update
- [x] Build process or tooling change
- [ ] Code style or formatting change
- [ ] Other (please describe)

[//]: # 'Uncomment the following lines if your change is related to an issue'
[//]: # '## Related Issues (if any)'
[//]: #
[//]: # 'Fixes #(issue number)'

## Checklist

- [x] My code follows the project's style guidelines
- [ ] I've tested my changes locally
- [ ] I've updated documentation if needed


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added automated bundle-size tracking for app routes, with build-time reports and PR comments showing first-load JavaScript changes.
  * Added a refreshed bundle size baseline so future comparisons are measured against updated route and shared asset sizes.


<!-- end of auto-generated comment: release notes by coderabbit.ai -->