### PR TITLE
feat(sidebar): implement items drag and drop

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -14,6 +14,7 @@
         "@ai-sdk/react": "^4.0.16",
         "@clerk/nextjs": "^7.5.12",
         "@clerk/themes": "^2.4.57",
+        "@dnd-kit/core": "^6.3.1",
         "@hookform/resolvers": "^5.4.0",
         "@lexical/react": "^0.46.0",
         "@sentry/nextjs": "^10.63.0",
@@ -1007,6 +1008,45 @@
       "license": "MIT",
       "engines": {
         "node": ">=22"
+      }
+    },
+    "node_modules/@dnd-kit/accessibility": {
+      "version": "3.1.1",
+      "resolved": "https://registry.npmjs.org/@dnd-kit/accessibility/-/accessibility-3.1.1.tgz",
+      "integrity": "sha512-2P+YgaXF+gRsIihwwY1gCsQSYnu9Zyj2py8kY5fFvUM1qm2WA2u639R6YNVfU4GWr+ZM5mqEsfHZZLoRONbemw==",
+      "license": "MIT",
+      "dependencies": {
+        "tslib": "^2.0.0"
+      },
+      "peerDependencies": {
+        "react": ">=16.8.0"
+      }
+    },
+    "node_modules/@dnd-kit/core": {
+      "version": "6.3.1",
+      "resolved": "https://registry.npmjs.org/@dnd-kit/core/-/core-6.3.1.tgz",
+      "integrity": "sha512-xkGBRQQab4RLwgXxoqETICr6S5JlogafbhNsidmrkVv2YRs5MLwpjoF2qpiGjQt8S9AoxtIV603s0GIUpY5eYQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@dnd-kit/accessibility": "^3.1.1",
+        "@dnd-kit/utilities": "^3.2.2",
+        "tslib": "^2.0.0"
+      },
+      "peerDependencies": {
+        "react": ">=16.8.0",
+        "react-dom": ">=16.8.0"
+      }
+    },
+    "node_modules/@dnd-kit/utilities": {
+      "version": "3.2.2",
+      "resolved": "https://registry.npmjs.org/@dnd-kit/utilities/-/utilities-3.2.2.tgz",
+      "integrity": "sha512-+MKAJEOfaBe5SmV6t34p80MMKhjvUz0vRrvVJbPT0WElzaOJ/1xs+D+KDv+tD/NE5ujfrChEcshd4fLn0wpiqg==",
+      "license": "MIT",
+      "dependencies": {
+        "tslib": "^2.0.0"
+      },
+      "peerDependencies": {
+        "react": ">=16.8.0"
       }
     },
     "node_modules/@ecies/ciphers": {

--- a/package.json
+++ b/package.json
@@ -73,6 +73,7 @@
     "@ai-sdk/react": "^4.0.16",
     "@clerk/nextjs": "^7.5.12",
     "@clerk/themes": "^2.4.57",
+    "@dnd-kit/core": "^6.3.1",
     "@hookform/resolvers": "^5.4.0",
     "@lexical/react": "^0.46.0",
     "@sentry/nextjs": "^10.63.0",

--- a/src/components/layout/sidebar-directory-tree.tsx
+++ b/src/components/layout/sidebar-directory-tree.tsx
@@ -1,6 +1,20 @@
 'use client';
 
 import {
+  useSensor,
+  DndContext,
+  useSensors,
+  DragOverlay,
+  useDraggable,
+  useDroppable,
+  PointerSensor,
+  closestCenter,
+  type DragEndEvent,
+  type DragOverEvent,
+  type DragStartEvent,
+} from '@dnd-kit/core';
+import {
+  FileIcon,
   TrashIcon,
   FolderIcon,
   FilePlusIcon,
@@ -28,16 +42,145 @@ import {
 } from '@/components/ui/dropdown-menu';
 import useIsMobile from '@/lib/hooks/use-is-mobile';
 import type { DocumentItem } from '@/lib/models/document.model';
+import type { FolderItem } from '@/lib/models/folder.model';
 import type { FolderNode } from '@/lib/utils/build-directory-tree';
 import cn from '@/lib/utils/cn';
 import getFolderSubtreeIds from '@/lib/utils/get-folder-subtree-ids';
+
+const HOVER_EXPAND_DELAY = 500;
 
 type SidebarDirectoryTreeProps = {
   documents: DocumentItem[];
   folders: FolderNode[];
 };
 
+type DirectoryDragData = {
+  id: string;
+  kind: 'document' | 'folder';
+  label: string;
+  parentId: string | null;
+};
+
+type FolderDropData = {
+  id: string;
+  kind: 'folder';
+};
+
+type SelfDropData = {
+  id: string;
+  itemKind: DirectoryDragData['kind'];
+  kind: 'self';
+};
+
+type DirectoryDropData = FolderDropData | SelfDropData;
+
 export default function SidebarDirectoryTree({ documents, folders }: SidebarDirectoryTreeProps) {
+  const { expandedFolderIds, expandFolderAndAncestors, folders: allFolders, moveDirectoryItem } = useDocument();
+  const [activeDragItem, setActiveDragItem] = React.useState<DirectoryDragData | null>(null);
+  const hoverExpandTimeoutRef = React.useRef<ReturnType<typeof setTimeout> | null>(null);
+  const hoveredFolderIdRef = React.useRef<string | null>(null);
+  const sensors = useSensors(
+    useSensor(PointerSensor, {
+      activationConstraint: {
+        delay: 100,
+        tolerance: 6,
+      },
+    })
+  );
+
+  const clearHoverExpandTimeout = React.useCallback(() => {
+    if (hoverExpandTimeoutRef.current) {
+      clearTimeout(hoverExpandTimeoutRef.current);
+      hoverExpandTimeoutRef.current = null;
+    }
+  }, []);
+
+  const resetDragState = React.useCallback(() => {
+    clearHoverExpandTimeout();
+    hoveredFolderIdRef.current = null;
+    setActiveDragItem(null);
+  }, [clearHoverExpandTimeout]);
+
+  React.useEffect(() => {
+    return clearHoverExpandTimeout;
+  }, [clearHoverExpandTimeout]);
+
+  function handleDragStart(event: DragStartEvent) {
+    const dragData = getDirectoryDragData(event.active.data.current);
+
+    if (dragData) {
+      setActiveDragItem(dragData);
+    }
+  }
+
+  function handleDragOver(event: DragOverEvent) {
+    const dropData = getFolderDropData(event.over?.data.current);
+
+    if (!dropData || expandedFolderIds.has(dropData.id)) {
+      hoveredFolderIdRef.current = null;
+      clearHoverExpandTimeout();
+
+      return;
+    }
+
+    if (hoveredFolderIdRef.current === dropData.id) {
+      return;
+    }
+
+    clearHoverExpandTimeout();
+    hoveredFolderIdRef.current = dropData.id;
+    hoverExpandTimeoutRef.current = setTimeout(() => {
+      expandFolderAndAncestors(dropData.id);
+      hoverExpandTimeoutRef.current = null;
+    }, HOVER_EXPAND_DELAY);
+  }
+
+  async function handleDragEnd(event: DragEndEvent) {
+    const dragData = getDirectoryDragData(event.active.data.current);
+    const dropData = getDirectoryDropData(event.over?.data.current);
+
+    resetDragState();
+
+    if (!dragData || !dropData || dropData.kind === 'self' || !canDropIntoFolder(dragData, dropData.id, allFolders)) {
+      return;
+    }
+
+    await moveDirectoryItem({
+      destinationFolderId: dropData.id,
+      id: dragData.id,
+      kind: dragData.kind,
+    });
+  }
+
+  return (
+    <DndContext
+      sensors={sensors}
+      onDragOver={handleDragOver}
+      onDragCancel={resetDragState}
+      onDragStart={handleDragStart}
+      collisionDetection={closestCenter}
+      onDragEnd={(event) => {
+        void handleDragEnd(event);
+      }}
+    >
+      <SidebarDirectoryTreeList folders={folders} documents={documents} />
+      <DragOverlay>
+        {activeDragItem && (
+          <div className="bg-popover text-popover-foreground border-border flex h-8 max-w-64 items-center gap-2 rounded-md border px-3 text-sm font-medium shadow-lg">
+            {activeDragItem.kind === 'folder' ? (
+              <FolderIcon className="size-4 shrink-0" />
+            ) : (
+              <FileIcon className="size-4 shrink-0" />
+            )}
+            <span className="overflow-hidden text-ellipsis whitespace-nowrap">{activeDragItem.label}</span>
+          </div>
+        )}
+      </DragOverlay>
+    </DndContext>
+  );
+}
+
+function SidebarDirectoryTreeList({ documents, folders }: SidebarDirectoryTreeProps) {
   return (
     <ul className="flex flex-col gap-1">
       {folders.map((folder) => {
@@ -54,25 +197,71 @@ function SidebarDocumentItem({ document }: { document: DocumentItem }) {
   const isMobile = useIsMobile();
   const { toggleSidebar } = useSidebar();
   const { activeDocument, documentIdBeingRemoved, setDocumentIdInteractedWith } = useDocument();
+  const {
+    active,
+    attributes,
+    isDragging,
+    listeners,
+    setActivatorNodeRef,
+    setNodeRef: setDraggableNodeRef,
+  } = useDraggable({
+    disabled: documentIdBeingRemoved === document.id,
+    id: getDraggableId('document', document.id),
+    attributes: {
+      role: 'link',
+      roleDescription: 'draggable document',
+    },
+    data: {
+      id: document.id,
+      kind: 'document',
+      label: document.title || 'Untitled',
+      parentId: document.folderId ?? null,
+    } satisfies DirectoryDragData,
+  });
+  const activeDragData = getDirectoryDragData(active?.data.current);
+  const { isOver: isSelfOver, setNodeRef: setSelfDropNodeRef } = useDroppable({
+    disabled: !isSameDirectoryItem(activeDragData, 'document', document.id),
+    id: getSelfDropId('document', document.id),
+    data: {
+      id: document.id,
+      itemKind: 'document',
+      kind: 'self',
+    } satisfies SelfDropData,
+  });
+  const setDocumentNodeRef = React.useCallback(
+    (node: HTMLLIElement | null) => {
+      setDraggableNodeRef(node);
+      setSelfDropNodeRef(node);
+    },
+    [setDraggableNodeRef, setSelfDropNodeRef]
+  );
 
   return (
     <li
-      className="relative flex items-center rounded-md"
+      ref={setDocumentNodeRef}
       onMouseLeave={() => {
         setDocumentIdInteractedWith('');
       }}
       onMouseEnter={() => {
         setDocumentIdInteractedWith(document.id);
       }}
+      className={cn(
+        'relative flex items-center rounded-md',
+        isDragging && 'opacity-40',
+        isSelfOver && 'ring-primary/30 ring-1'
+      )}
     >
       <Link
         prefetch={false}
+        ref={setActivatorNodeRef}
         href={{ pathname: '/', query: { document: document.id } }}
         className={cn(
-          'focus:ring-accent flex-1 overflow-hidden focus:ring-2 focus:ring-offset-2 has-[.pending]:cursor-wait',
+          'focus:ring-accent flex-1 touch-none overflow-hidden focus:ring-2 focus:ring-offset-2 has-[.pending]:cursor-wait',
           documentIdBeingRemoved === document.id && 'pointer-events-none cursor-wait',
           document.id === activeDocument?.id && 'cursor-default'
         )}
+        {...listeners}
+        {...attributes}
         onClick={(e) => {
           if (
             document.id === activeDocument?.id ||
@@ -113,6 +302,53 @@ function SidebarFolderItem({ folder }: { folder: FolderNode }) {
   const isBeingRemoved = folderIdBeingRemoved === folder.id;
   const hasChildren = folder.subfolders.length > 0 || folder.documents.length > 0;
   const subtreeIds = getFolderSubtreeIds(folders, folder.id);
+  const {
+    active,
+    attributes,
+    isDragging,
+    listeners,
+    setActivatorNodeRef,
+    setNodeRef: setDraggableNodeRef,
+  } = useDraggable({
+    disabled: isBeingRemoved,
+    id: getDraggableId('folder', folder.id),
+    attributes: {
+      roleDescription: 'draggable folder',
+    },
+    data: {
+      id: folder.id,
+      kind: 'folder',
+      label: folder.name || 'Untitled',
+      parentId: folder.parentId ?? null,
+    } satisfies DirectoryDragData,
+  });
+  const activeDragData = getDirectoryDragData(active?.data.current);
+  const isDropDisabled = !activeDragData || isBeingRemoved || !canDropIntoFolder(activeDragData, folder.id, folders);
+  const { isOver, setNodeRef: setDroppableNodeRef } = useDroppable({
+    disabled: isDropDisabled,
+    id: getDroppableId(folder.id),
+    data: {
+      id: folder.id,
+      kind: 'folder',
+    } satisfies FolderDropData,
+  });
+  const { isOver: isSelfOver, setNodeRef: setSelfDropNodeRef } = useDroppable({
+    disabled: !isSameDirectoryItem(activeDragData, 'folder', folder.id),
+    id: getSelfDropId('folder', folder.id),
+    data: {
+      id: folder.id,
+      itemKind: 'folder',
+      kind: 'self',
+    } satisfies SelfDropData,
+  });
+  const setFolderNodeRef = React.useCallback(
+    (node: HTMLDivElement | null) => {
+      setDraggableNodeRef(node);
+      setDroppableNodeRef(node);
+      setSelfDropNodeRef(node);
+    },
+    [setDraggableNodeRef, setDroppableNodeRef, setSelfDropNodeRef]
+  );
   const canBeMoved =
     !!folder.parentId ||
     folders.some((item) => {
@@ -128,25 +364,34 @@ function SidebarFolderItem({ folder }: { folder: FolderNode }) {
         }}
       >
         <div
-          className="flex items-center"
+          ref={setFolderNodeRef}
           onMouseLeave={() => {
             setFolderIdInteractedWith('');
           }}
           onMouseEnter={() => {
             setFolderIdInteractedWith(folder.id);
           }}
+          className={cn(
+            'flex items-center rounded-md',
+            isDragging && 'opacity-40',
+            isSelfOver && 'ring-primary/30 ring-1'
+          )}
         >
           <CollapsibleTrigger asChild>
             <Button
               size="sm"
               variant="ghost"
               disabled={isBeingRemoved}
+              ref={setActivatorNodeRef}
               className={cn(
-                'flex-1 justify-start overflow-hidden rounded-r-none pl-4! transition-none hover:bg-transparent dark:hover:bg-transparent',
+                'flex-1 touch-none justify-start overflow-hidden rounded-r-none pl-4! transition-none hover:bg-transparent dark:hover:bg-transparent',
                 isBeingRemoved && 'justify-between pr-0',
                 (folder.id === folderIdInteractedWith || folder.id === activeDropdownFolderId) &&
-                  'bg-secondary/50 hover:bg-secondary/50 dark:hover:bg-secondary/50 text-secondary-foreground'
+                  'bg-secondary/50 hover:bg-secondary/50 dark:hover:bg-secondary/50 text-secondary-foreground',
+                isOver && 'bg-primary/10 text-primary hover:bg-primary/10 dark:hover:bg-primary/10'
               )}
+              {...listeners}
+              {...attributes}
             >
               {isExpanded ? <FolderOpenIcon className="size-4 shrink-0" /> : <FolderIcon className="size-4 shrink-0" />}
               <p className="flex-1 overflow-hidden text-left text-sm font-medium text-ellipsis">{folder.name}</p>
@@ -234,7 +479,7 @@ function SidebarFolderItem({ folder }: { folder: FolderNode }) {
         <CollapsibleContent>
           {hasChildren ? (
             <div className="border-border mt-1 ml-4 border-l pl-1">
-              <SidebarDirectoryTree folders={folder.subfolders} documents={folder.documents} />
+              <SidebarDirectoryTreeList folders={folder.subfolders} documents={folder.documents} />
             </div>
           ) : (
             <p className="text-muted-foreground mt-1 ml-6 py-1 pl-4 text-xs">Empty folder</p>
@@ -243,4 +488,98 @@ function SidebarFolderItem({ folder }: { folder: FolderNode }) {
       </Collapsible>
     </li>
   );
+}
+
+function getDraggableId(kind: DirectoryDragData['kind'], id: string) {
+  return `${kind}:${id}`;
+}
+
+function getDroppableId(id: string) {
+  return `folder-drop:${id}`;
+}
+
+function getSelfDropId(kind: DirectoryDragData['kind'], id: string) {
+  return `self:${kind}:${id}`;
+}
+
+function getDirectoryDragData(data: unknown): DirectoryDragData | null {
+  if (!data || typeof data !== 'object') {
+    return null;
+  }
+
+  const value = data as Partial<DirectoryDragData>;
+
+  if (
+    typeof value.id === 'string' &&
+    (value.kind === 'document' || value.kind === 'folder') &&
+    typeof value.label === 'string'
+  ) {
+    return {
+      id: value.id,
+      kind: value.kind,
+      label: value.label,
+      parentId: typeof value.parentId === 'string' ? value.parentId : null,
+    };
+  }
+
+  return null;
+}
+
+function getFolderDropData(data: unknown): FolderDropData | null {
+  if (!data || typeof data !== 'object') {
+    return null;
+  }
+
+  const value = data as Partial<FolderDropData>;
+
+  if (typeof value.id === 'string' && value.kind === 'folder') {
+    return {
+      id: value.id,
+      kind: value.kind,
+    };
+  }
+
+  return null;
+}
+
+function getDirectoryDropData(data: unknown): DirectoryDropData | null {
+  return getSelfDropData(data) ?? getFolderDropData(data);
+}
+
+function getSelfDropData(data: unknown): SelfDropData | null {
+  if (!data || typeof data !== 'object') {
+    return null;
+  }
+
+  const value = data as Partial<SelfDropData>;
+
+  if (
+    typeof value.id === 'string' &&
+    value.kind === 'self' &&
+    (value.itemKind === 'document' || value.itemKind === 'folder')
+  ) {
+    return {
+      id: value.id,
+      itemKind: value.itemKind,
+      kind: 'self',
+    };
+  }
+
+  return null;
+}
+
+function isSameDirectoryItem(data: DirectoryDragData | null, kind: DirectoryDragData['kind'], id: string) {
+  return data?.kind === kind && data.id === id;
+}
+
+function canDropIntoFolder(dragData: DirectoryDragData, destinationFolderId: string, folders: FolderItem[]) {
+  if (dragData.parentId === destinationFolderId) {
+    return false;
+  }
+
+  if (dragData.kind === 'document') {
+    return true;
+  }
+
+  return !getFolderSubtreeIds(folders, dragData.id).has(destinationFolderId);
 }

--- a/src/components/providers/document-provider.tsx
+++ b/src/components/providers/document-provider.tsx
@@ -48,6 +48,10 @@ type MoveDialogTarget = {
   kind: 'document' | 'folder';
 };
 
+type MoveDirectoryItemOptions = MoveDialogTarget & {
+  destinationFolderId: string;
+};
+
 type DocumentContextType = {
   activeDocument: DocumentItem | null;
   activeDropdownDocumentId: string | null;
@@ -61,11 +65,13 @@ type DocumentContextType = {
   hasUnsavedEditorChanges: boolean;
   isEditorEmpty: boolean;
   closeActiveDocument: () => void;
+  expandFolderAndAncestors: (folderId: string) => void;
   handleDropdownOpenChange: (isOpen: boolean, documentId: string) => void;
   handleEditorChange: (editorState: EditorState) => void;
   handleFolderDropdownOpenChange: (isOpen: boolean, folderId: string) => void;
   initiateDocumentRemoval: (documentId: string) => Promise<void>;
   initiateFolderRemoval: (folderId: string) => Promise<void>;
+  moveDirectoryItem: (options: MoveDirectoryItemOptions) => Promise<void>;
   openDocumentDialog: (options?: DirectoryDialogOptions) => void;
   openFolderDialog: (options?: DirectoryDialogOptions) => void;
   openMoveDialog: (target: MoveDialogTarget) => void;
@@ -629,6 +635,63 @@ export default function DocumentProvider({ children, documents, folders, isAuthe
     [confirm, activeDocument, closeActiveDocument, folderIdInteractedWith, folders]
   );
 
+  const moveDirectoryItem = React.useCallback(
+    async ({ destinationFolderId, id, kind }: MoveDirectoryItemOptions) => {
+      const destination = folders.find((folder) => {
+        return folder.id === destinationFolderId;
+      });
+
+      if (!destination) {
+        return;
+      }
+
+      const targetLabel = kind === 'document' ? 'Document' : 'Folder';
+
+      try {
+        if (kind === 'document') {
+          const document = documents.find((item) => {
+            return item.id === id;
+          });
+
+          if (!document || document.folderId === destinationFolderId) {
+            return;
+          }
+
+          await updateDocument(id, { folderId: destinationFolderId });
+          posthog.capture('document_moved_to_folder', {
+            documentId: id,
+            folderId: destinationFolderId,
+          });
+        } else {
+          const folder = folders.find((item) => {
+            return item.id === id;
+          });
+          const excludedFolderIds = getFolderSubtreeIds(folders, id);
+
+          if (!folder || folder.parentId === destinationFolderId || excludedFolderIds.has(destinationFolderId)) {
+            return;
+          }
+
+          await updateFolder(id, { parentId: destinationFolderId });
+          posthog.capture('folder_moved_to_folder', {
+            folderId: id,
+            parentId: destinationFolderId,
+          });
+        }
+
+        expandFolderAndAncestors(destinationFolderId);
+        toast.success(`${targetLabel} moved successfully`);
+      } catch (error) {
+        Sentry.captureException(error);
+        console.error(`Error moving ${targetLabel.toLowerCase()}: `, error);
+        toast.error(`Error moving ${targetLabel.toLowerCase()}`, {
+          description: getErrorMessage(error),
+        });
+      }
+    },
+    [documents, expandFolderAndAncestors, folders]
+  );
+
   const moveDialogFolderOptions = React.useMemo(() => {
     if (!moveDialogTarget) {
       return [];
@@ -694,6 +757,7 @@ export default function DocumentProvider({ children, documents, folders, isAuthe
       documentIdBeingRemoved,
       documentIdInteractedWith,
       expandedFolderIds,
+      expandFolderAndAncestors,
       folderIdBeingRemoved,
       folderIdInteractedWith,
       folders,
@@ -704,6 +768,7 @@ export default function DocumentProvider({ children, documents, folders, isAuthe
       initiateDocumentRemoval,
       initiateFolderRemoval,
       isEditorEmpty,
+      moveDirectoryItem,
       openDocumentDialog,
       openFolderDialog,
       openMoveDialog,
@@ -714,12 +779,14 @@ export default function DocumentProvider({ children, documents, folders, isAuthe
   }, [
     closeActiveDocument,
     documentIdInteractedWith,
+    expandFolderAndAncestors,
     expandedFolderIds,
     folderIdInteractedWith,
     folders,
     openDocumentDialog,
     openFolderDialog,
     openMoveDialog,
+    moveDirectoryItem,
     handleDropdownOpenChange,
     handleFolderDropdownOpenChange,
     activeDropdownDocumentId,


### PR DESCRIPTION
## Description

Documents and folders can now be dragged and dropped into other folders inside the sidebar, which executes the move operation.

## Type of Change

- [ ] Bug fix
- [x] New feature
- [ ] Documentation update
- [ ] Refactoring
- [ ] Performance improvement
- [ ] Test addition or update
- [ ] Build process or tooling change
- [ ] Code style or formatting change
- [ ] Other (please describe)

[//]: # 'Uncomment the following lines if your change is related to an issue'
[//]: # '## Related Issues (if any)'
[//]: #
[//]: # 'Fixes #(issue number)'

## Checklist

- [x] My code follows the project's style guidelines
- [x] I've tested my changes locally
- [ ] I've updated documentation if needed


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added drag-and-drop support for reorganizing documents and folders in the sidebar.
  * Items can now be moved into folders with visual feedback during dragging and hovering.
  * Destination folders expand automatically after a successful move.

* **Bug Fixes**
  * Prevented invalid moves that would create circular folder structures or drop items into the same location.
  * Improved handling for unavailable or unsupported drop targets to avoid accidental reordering errors.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->