### PR TITLE
feat(editor): improve table editing ux

### DIFF
--- a/src/components/custom/table-size-picker.tsx
+++ b/src/components/custom/table-size-picker.tsx
@@ -11,8 +11,42 @@ type TableSizePickerProps = {
 export default function TableSizePicker({ maxColumns = 10, maxRows = 8, onSelect }: TableSizePickerProps) {
   const [hovered, setHovered] = React.useState<{ columns: number; rows: number } | null>(null);
 
+  function handleKeyDown(event: React.KeyboardEvent<HTMLDivElement>) {
+    if (!['ArrowUp', 'ArrowDown', 'ArrowLeft', 'ArrowRight', 'Enter'].includes(event.key)) {
+      return;
+    }
+
+    event.preventDefault();
+    event.stopPropagation();
+
+    const current = hovered ?? { columns: 1, rows: 1 };
+
+    if (event.key === 'Enter') {
+      onSelect(current.rows, current.columns);
+
+      return;
+    }
+
+    if (hovered === null) {
+      setHovered(current);
+
+      return;
+    }
+
+    const next = {
+      ArrowDown: { ...current, rows: Math.min(current.rows + 1, maxRows) },
+      ArrowLeft: { ...current, columns: Math.max(current.columns - 1, 1) },
+      ArrowRight: { ...current, columns: Math.min(current.columns + 1, maxColumns) },
+      ArrowUp: { ...current, rows: Math.max(current.rows - 1, 1) },
+    }[event.key];
+
+    if (next) {
+      setHovered(next);
+    }
+  }
+
   return (
-    <div className="space-y-2">
+    <div className="space-y-2" onKeyDown={handleKeyDown}>
       <div
         role="grid"
         className="grid w-fit gap-1"

--- a/src/components/editor/plugins/shortcuts-plugin.ts
+++ b/src/components/editor/plugins/shortcuts-plugin.ts
@@ -1,7 +1,6 @@
 import { TOGGLE_LINK_COMMAND } from '@lexical/link';
 import { useLexicalComposerContext } from '@lexical/react/LexicalComposerContext';
 import type { HeadingTagType } from '@lexical/rich-text';
-import { INSERT_TABLE_COMMAND } from '@lexical/table';
 import {
   $getRoot,
   $getSelection,
@@ -17,6 +16,7 @@ import {
 import * as React from 'react';
 
 import { ToolbarStateContext } from '@/components/providers/editor-toolbar-state-provider';
+import OPEN_INSERT_TABLE_POPOVER_COMMAND from '@/lib/constants/editor-custom-commands';
 import { MAX_ALLOWED_FONT_SIZE, MIN_ALLOWED_FONT_SIZE } from '@/lib/constants/initial-editor-toolbar-state';
 import {
   formatQuote,
@@ -227,11 +227,7 @@ export default function ShortcutsPlugin() {
       {
         check: isInsertTable,
         execute: () => {
-          editor.dispatchCommand(INSERT_TABLE_COMMAND, {
-            columns: '5',
-            includeHeaders: { columns: false, rows: true },
-            rows: '5',
-          });
+          editor.dispatchCommand(OPEN_INSERT_TABLE_POPOVER_COMMAND, undefined);
         },
       },
       {

--- a/src/components/editor/plugins/table-cell-resizer-plugin.tsx
+++ b/src/components/editor/plugins/table-cell-resizer-plugin.tsx
@@ -365,15 +365,22 @@ function TableCellResizer({ editor }: { editor: LexicalEditor }) {
 
       styles[draggingDirection].backgroundColor = 'var(--primary)';
       styles[draggingDirection].mixBlendMode = 'unset';
-    } else if (!draggingDirection && hoveredDirection === 'right') {
+    } else if (!draggingDirection && hoveredDirection !== null) {
       const highlightStart = RESIZE_ZONE_WIDTH / 2 - 1;
+      const gradientAngle = hoveredDirection === 'right' ? '90deg' : '180deg';
 
-      styles.right.backgroundImage = `linear-gradient(90deg, transparent ${highlightStart}px, var(--primary) ${highlightStart}px, var(--primary) ${highlightStart + 2}px, transparent ${highlightStart + 2}px)`;
-      styles.right.mixBlendMode = 'unset';
+      styles[hoveredDirection].backgroundImage =
+        `linear-gradient(${gradientAngle}, transparent ${highlightStart}px, var(--primary) ${highlightStart}px, var(--primary) ${highlightStart + 2}px, transparent ${highlightStart + 2}px)`;
+      styles[hoveredDirection].mixBlendMode = 'unset';
 
-      if (tableRect) {
+      if (tableRect && hoveredDirection === 'right') {
         styles.right.top = `${window.scrollY + tableRect.top}px`;
         styles.right.height = `${tableRect.height}px`;
+      }
+
+      if (tableRect && hoveredDirection === 'bottom') {
+        styles.bottom.left = `${window.scrollX + tableRect.left}px`;
+        styles.bottom.width = `${tableRect.width}px`;
       }
     }
 
@@ -411,9 +418,11 @@ function TableCellResizer({ editor }: { editor: LexicalEditor }) {
             onPointerEnter={handlePointerEnter('right')}
           />
           <div
+            onPointerLeave={handlePointerLeave}
             className="editor-table-cell-resizer"
             onPointerDown={toggleResize('bottom')}
             style={resizerStyles.bottom || undefined}
+            onPointerEnter={handlePointerEnter('bottom')}
           />
         </>
       )}

--- a/src/components/editor/plugins/table-hover-actions-plugin.tsx
+++ b/src/components/editor/plugins/table-hover-actions-plugin.tsx
@@ -8,8 +8,7 @@ import {
   $insertTableRowAtSelection,
   $insertTableColumnAtSelection,
 } from '@lexical/table';
-import { mergeRegister } from '@lexical/utils';
-import { $getNodeByKey, isHTMLElement, $getNearestNodeFromDOMNode } from 'lexical';
+import { $getNodeByKey, $getNearestNodeFromDOMNode } from 'lexical';
 import debounce from 'lodash.debounce';
 import { PlusIcon } from 'lucide-react';
 import * as React from 'react';
@@ -17,6 +16,7 @@ import { createPortal } from 'react-dom';
 
 const BUTTON_THICKNESS = 16;
 const BUTTON_GAP = 4;
+const HOVER_MARGIN = 4;
 
 type HoveredTable = {
   isRightEdgeClipped: boolean;
@@ -24,9 +24,20 @@ type HoveredTable = {
   tableRect: DOMRect;
 };
 
+function isPointerNearTable(tableElement: HTMLTableElement, clientX: number, clientY: number) {
+  const rect = tableElement.getBoundingClientRect();
+  const outerMargin = BUTTON_THICKNESS + BUTTON_GAP + HOVER_MARGIN;
+
+  return (
+    clientX >= rect.left - HOVER_MARGIN &&
+    clientX <= rect.right + outerMargin &&
+    clientY >= rect.top - HOVER_MARGIN &&
+    clientY <= rect.bottom + outerMargin
+  );
+}
+
 export default function TableHoverActionsPlugin({ anchor }: { anchor: HTMLElement }) {
   const [editor] = useLexicalComposerContext();
-  const containerRef = React.useRef<HTMLDivElement | null>(null);
   const [hoveredTable, setHoveredTable] = React.useState<HoveredTable | null>(null);
 
   React.useEffect(() => {
@@ -37,16 +48,17 @@ export default function TableHoverActionsPlugin({ anchor }: { anchor: HTMLElemen
         return;
       }
 
-      const target = event.target;
+      const rootElement = editor.getRootElement();
 
-      if (!isHTMLElement(target) || target.closest('[data-table-resizer]')) {
+      if (!rootElement) {
         return;
       }
 
-      const tableElement = target.closest<HTMLTableElement>('table.editor-table');
-      const rootElement = editor.getRootElement();
+      const tableElement = [...rootElement.querySelectorAll<HTMLTableElement>('table.editor-table')].find((el) => {
+        return isPointerNearTable(el, event.clientX, event.clientY);
+      });
 
-      if (!tableElement || !rootElement?.contains(tableElement)) {
+      if (!tableElement) {
         setHoveredTable(null);
 
         return;
@@ -71,38 +83,23 @@ export default function TableHoverActionsPlugin({ anchor }: { anchor: HTMLElemen
       });
     }, 50);
 
-    function onPointerLeave(event: PointerEvent) {
-      const relatedTarget = event.relatedTarget;
-
-      if (relatedTarget instanceof Node && containerRef.current?.contains(relatedTarget)) {
-        return;
-      }
-
-      onPointerMove.cancel();
-      setHoveredTable(null);
-    }
-
     function hide() {
       onPointerMove.cancel();
       setHoveredTable(null);
     }
 
+    document.addEventListener('pointermove', onPointerMove);
+    document.addEventListener('pointerleave', hide);
     anchor.addEventListener('scroll', hide);
     window.addEventListener('resize', hide);
 
-    return mergeRegister(
-      editor.registerRootListener((rootElement, prevRootElement) => {
-        prevRootElement?.removeEventListener('pointermove', onPointerMove);
-        prevRootElement?.removeEventListener('pointerleave', onPointerLeave);
-        rootElement?.addEventListener('pointermove', onPointerMove);
-        rootElement?.addEventListener('pointerleave', onPointerLeave);
-      }),
-      () => {
-        onPointerMove.cancel();
-        anchor.removeEventListener('scroll', hide);
-        window.removeEventListener('resize', hide);
-      }
-    );
+    return () => {
+      onPointerMove.cancel();
+      document.removeEventListener('pointermove', onPointerMove);
+      document.removeEventListener('pointerleave', hide);
+      anchor.removeEventListener('scroll', hide);
+      window.removeEventListener('resize', hide);
+    };
   }, [editor, anchor]);
 
   function appendRow() {
@@ -167,7 +164,7 @@ export default function TableHoverActionsPlugin({ anchor }: { anchor: HTMLElemen
     'bg-muted hover:bg-accent text-muted-foreground hover:text-accent-foreground flex cursor-pointer items-center justify-center rounded-sm transition-colors';
 
   return createPortal(
-    <div ref={containerRef} className="absolute top-0 left-0 z-10">
+    <div className="absolute top-0 left-0 z-10">
       <button
         type="button"
         onClick={appendRow}

--- a/src/components/editor/plugins/toolbar-editor-plugin.tsx
+++ b/src/components/editor/plugins/toolbar-editor-plugin.tsx
@@ -17,6 +17,7 @@ import {
   type TextFormatType,
   FORMAT_ELEMENT_COMMAND,
   INDENT_CONTENT_COMMAND,
+  COMMAND_PRIORITY_NORMAL,
   OUTDENT_CONTENT_COMMAND,
 } from 'lexical';
 import {
@@ -72,8 +73,9 @@ import {
 import { Popover, PopoverContent, PopoverTrigger } from '@/components/ui/popover';
 import { Select, SelectItem, SelectValue, SelectContent, SelectTrigger } from '@/components/ui/select';
 import { Separator } from '@/components/ui/separator';
-import { TooltipProvider } from '@/components/ui/tooltip';
+import { Tooltip, TooltipContent, TooltipTrigger, TooltipProvider } from '@/components/ui/tooltip';
 import { updateDocument } from '@/lib/actions/document.actions';
+import OPEN_INSERT_TABLE_POPOVER_COMMAND from '@/lib/constants/editor-custom-commands';
 import { default as KBD } from '@/lib/constants/editor-shortcuts';
 import type { Alignment } from '@/lib/constants/editor-toolbar-alignments';
 import ELEMENT_FORMAT_OPTIONS from '@/lib/constants/editor-toolbar-alignments';
@@ -137,6 +139,18 @@ export default function ToolbarEditorPlugin() {
   React.useEffect(() => {
     setMounted(true);
   }, []);
+
+  React.useEffect(() => {
+    return editor.registerCommand(
+      OPEN_INSERT_TABLE_POPOVER_COMMAND,
+      () => {
+        setIsTableSizePickerOpen(true);
+
+        return true;
+      },
+      COMMAND_PRIORITY_NORMAL
+    );
+  }, [editor]);
 
   const foreground = useCssVar('--foreground');
   const background = useCssVar('--background');
@@ -559,11 +573,18 @@ export default function ToolbarEditorPlugin() {
         </ButtonGroup>
 
         <Popover open={isTableSizePickerOpen} onOpenChange={setIsTableSizePickerOpen}>
-          <PopoverTrigger asChild>
-            <Button size="icon" variant="ghost" className="shrink-0" aria-label="Insert table">
-              <TableIcon />
-            </Button>
-          </PopoverTrigger>
+          <Tooltip delayDuration={tooltipGroup.getTooltipProps().delayDuration}>
+            <TooltipTrigger asChild onMouseEnter={tooltipGroup.getTooltipProps().onMouseEnter}>
+              <PopoverTrigger asChild>
+                <Button size="icon" variant="ghost" className="shrink-0" aria-label="Insert table">
+                  <TableIcon />
+                </Button>
+              </PopoverTrigger>
+            </TooltipTrigger>
+            <TooltipContent className="flex items-center gap-2 p-2 pr-2.5">
+              Insert table <Shortcut keys={KBD.INSERT_TABLE} />
+            </TooltipContent>
+          </Tooltip>
           <PopoverContent className="w-fit">
             <TableSizePicker
               onSelect={(rows, columns) => {

--- a/src/lib/constants/editor-custom-commands.ts
+++ b/src/lib/constants/editor-custom-commands.ts
@@ -1,0 +1,5 @@
+import { createCommand } from 'lexical';
+
+const OPEN_INSERT_TABLE_POPOVER_COMMAND = createCommand<void>('OPEN_INSERT_TABLE_POPOVER_COMMAND');
+
+export default OPEN_INSERT_TABLE_POPOVER_COMMAND;

--- a/src/lib/constants/editor-extension.ts
+++ b/src/lib/constants/editor-extension.ts
@@ -3,9 +3,8 @@ import { HorizontalRuleNode, HorizontalRuleExtension } from '@lexical/extension'
 import { LinkNode, AutoLinkNode } from '@lexical/link';
 import { ListNode, ListItemNode } from '@lexical/list';
 import { QuoteNode, HeadingNode } from '@lexical/rich-text';
-import { TableExtension } from '@lexical/table';
-import { TableNode, TableRowNode, TableCellNode } from '@lexical/table';
-import { LineBreakNode, defineExtension } from 'lexical';
+import { TableNode, TableExtension } from '@lexical/table';
+import { $isRootNode, LineBreakNode, defineExtension, $createParagraphNode } from 'lexical';
 import { toast } from 'sonner';
 
 import { ImageNode } from '@/components/editor/nodes/image-node';
@@ -24,10 +23,7 @@ const LEXICAL_EDITOR_EXTENSION = defineExtension({
       QuoteNode,
       AutoLinkNode,
       LinkNode,
-      TableNode,
-      TableCellNode,
       HorizontalRuleNode,
-      TableRowNode,
       LineBreakNode,
       ImageNode,
     ];
@@ -35,6 +31,21 @@ const LEXICAL_EDITOR_EXTENSION = defineExtension({
   onError: (error) => {
     toast('An error occurred in the editor', {
       description: getErrorMessage(error),
+    });
+  },
+  register: (editor) => {
+    return editor.registerNodeTransform(TableNode, (tableNode) => {
+      if (!$isRootNode(tableNode.getParent())) {
+        return;
+      }
+
+      if (tableNode.getPreviousSibling() === null) {
+        tableNode.insertBefore($createParagraphNode());
+      }
+
+      if (tableNode.getNextSibling() === null) {
+        tableNode.insertAfter($createParagraphNode());
+      }
     });
   },
   theme: {


### PR DESCRIPTION
## Description

Route the insert-table shortcut through a new custom command so it opens the table size picker instead of inserting a fixed table, and add tooltip plus keyboard navigation for the picker. This also improves table hover and resize interactions around table edges, and ensures root-level tables always have paragraphs before and after them for safer editing.

## Type of Change

- [ ] Bug fix
- [x] New feature
- [ ] Documentation update
- [ ] Refactoring
- [ ] Performance improvement
- [ ] Test addition or update
- [ ] Build process or tooling change
- [ ] Code style or formatting change
- [ ] Other (please describe)

[//]: # 'Uncomment the following lines if your change is related to an issue'
[//]: # '## Related Issues (if any)'
[//]: #
[//]: # 'Fixes #(issue number)'

## Checklist

- [x] My code follows the project's style guidelines
- [x] I've tested my changes locally
- [ ] I've updated documentation if needed


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added keyboard support for inserting tables, including arrow-key navigation and Enter to confirm a size.
  * The table insert action now opens a table picker popover instead of inserting a fixed table immediately.
  * Improved table hover and resize interactions, including better support for bottom-edge resizing.

* **Bug Fixes**
  * Tables are now kept surrounded by paragraphs when inserted, improving cursor flow and editing behavior.
  * Table hover state is more reliable near tables and within scrollable areas.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->