### PR TITLE
feat(editor): add table cell color picker

### DIFF
--- a/src/components/editor/plugins/table-action-menu-plugin.tsx
+++ b/src/components/editor/plugins/table-action-menu-plugin.tsx
@@ -1,11 +1,10 @@
 'use client';
 
 import { useLexicalComposerContext } from '@lexical/react/LexicalComposerContext';
-import type { TableSelection } from '@lexical/table';
+import type { TableCellNode, TableSelection } from '@lexical/table';
 import {
   $mergeCells,
   $unmergeCell,
-  TableCellNode,
   getTableElement,
   $getNodeTriplet,
   $isTableCellNode,
@@ -246,24 +245,6 @@ export default function TableActionMenuPlugin({ anchor }: { anchor: HTMLElement 
       setIsMenuOpen(false);
     }
   }, [tableCellNode]);
-
-  React.useEffect(() => {
-    if (tableCellNode === null) {
-      return;
-    }
-
-    return editor.registerMutationListener(
-      TableCellNode,
-      (nodeMutations) => {
-        if (nodeMutations.get(tableCellNode.getKey()) === 'updated') {
-          editor.read('latest', () => {
-            setTableCellNode(tableCellNode.getLatest());
-          });
-        }
-      },
-      { skipInitialization: true }
-    );
-  }, [editor, tableCellNode]);
 
   function handleMenuOpenChange(open: boolean) {
     if (open) {

--- a/src/components/editor/plugins/table-action-menu-plugin.tsx
+++ b/src/components/editor/plugins/table-action-menu-plugin.tsx
@@ -64,6 +64,7 @@ import {
 } from '@/components/ui/dropdown-menu';
 import type { Alignment } from '@/lib/constants/editor-toolbar-alignments';
 import ELEMENT_FORMAT_OPTIONS from '@/lib/constants/editor-toolbar-alignments';
+import $getSelectedTableCells from '@/lib/utils/get-selected-table-cells';
 
 const MENU_BUTTON_SIZE = 20;
 const MENU_BUTTON_MARGIN = 4;
@@ -109,28 +110,6 @@ function $selectLastDescendant(node: ElementNode) {
   } else if (lastDescendant !== null) {
     lastDescendant.selectNext();
   }
-}
-
-function $getSelectedTableCells(selection: BaseSelection | null) {
-  const cells = new Set<TableCellNode>();
-
-  if ($isRangeSelection(selection) || $isTableSelection(selection)) {
-    const [anchorCell] = $getNodeTriplet(selection.anchor);
-
-    if ($isTableCellNode(anchorCell)) {
-      cells.add(anchorCell);
-    }
-
-    if ($isTableSelection(selection)) {
-      selection.getNodes().forEach((node) => {
-        if ($isTableCellNode(node)) {
-          cells.add(node);
-        }
-      });
-    }
-  }
-
-  return [...cells];
 }
 
 export default function TableActionMenuPlugin({ anchor }: { anchor: HTMLElement }) {

--- a/src/components/editor/plugins/table-hover-actions-plugin.tsx
+++ b/src/components/editor/plugins/table-hover-actions-plugin.tsx
@@ -38,16 +38,13 @@ function isPointerNearTable(tableElement: HTMLTableElement, clientX: number, cli
 
 export default function TableHoverActionsPlugin({ anchor }: { anchor: HTMLElement }) {
   const [editor] = useLexicalComposerContext();
+  const lastPointerPosRef = React.useRef<{ x: number; y: number } | null>(null);
   const [hoveredTable, setHoveredTable] = React.useState<HoveredTable | null>(null);
 
   React.useEffect(() => {
-    const onPointerMove = debounce((event: PointerEvent) => {
-      if (document.body.hasAttribute('data-table-resizing')) {
-        setHoveredTable(null);
+    let updateTimeoutId: ReturnType<typeof setTimeout> | undefined = undefined;
 
-        return;
-      }
-
+    function updateFromPoint(clientX: number, clientY: number) {
       const rootElement = editor.getRootElement();
 
       if (!rootElement) {
@@ -55,7 +52,7 @@ export default function TableHoverActionsPlugin({ anchor }: { anchor: HTMLElemen
       }
 
       const tableElement = [...rootElement.querySelectorAll<HTMLTableElement>('table.editor-table')].find((el) => {
-        return isPointerNearTable(el, event.clientX, event.clientY);
+        return isPointerNearTable(el, clientX, clientY);
       });
 
       if (!tableElement) {
@@ -81,12 +78,40 @@ export default function TableHoverActionsPlugin({ anchor }: { anchor: HTMLElemen
 
         setHoveredTable({ isRightEdgeClipped, tableNodeKey: tableNode.getKey(), tableRect });
       });
+    }
+
+    const debouncedUpdateFromPoint = debounce((clientX: number, clientY: number) => {
+      if (document.body.hasAttribute('data-table-resizing')) {
+        setHoveredTable(null);
+
+        return;
+      }
+
+      updateFromPoint(clientX, clientY);
     }, 50);
 
+    function onPointerMove(event: PointerEvent) {
+      lastPointerPosRef.current = { x: event.clientX, y: event.clientY };
+      debouncedUpdateFromPoint(event.clientX, event.clientY);
+    }
+
     function hide() {
-      onPointerMove.cancel();
+      debouncedUpdateFromPoint.cancel();
       setHoveredTable(null);
     }
+
+    const unregisterUpdateListener = editor.registerUpdateListener(() => {
+      const lastPointerPos = lastPointerPosRef.current;
+
+      if (!lastPointerPos || updateTimeoutId !== undefined) {
+        return;
+      }
+
+      updateTimeoutId = setTimeout(() => {
+        updateTimeoutId = undefined;
+        updateFromPoint(lastPointerPos.x, lastPointerPos.y);
+      }, 0);
+    });
 
     document.addEventListener('pointermove', onPointerMove);
     document.addEventListener('pointerleave', hide);
@@ -94,7 +119,9 @@ export default function TableHoverActionsPlugin({ anchor }: { anchor: HTMLElemen
     window.addEventListener('resize', hide);
 
     return () => {
-      onPointerMove.cancel();
+      unregisterUpdateListener();
+      clearTimeout(updateTimeoutId);
+      debouncedUpdateFromPoint.cancel();
       document.removeEventListener('pointermove', onPointerMove);
       document.removeEventListener('pointerleave', hide);
       anchor.removeEventListener('scroll', hide);

--- a/src/components/editor/plugins/table-hover-actions-plugin.tsx
+++ b/src/components/editor/plugins/table-hover-actions-plugin.tsx
@@ -97,6 +97,9 @@ export default function TableHoverActionsPlugin({ anchor }: { anchor: HTMLElemen
 
     function hide() {
       debouncedUpdateFromPoint.cancel();
+      clearTimeout(updateTimeoutId);
+      updateTimeoutId = undefined;
+      lastPointerPosRef.current = null;
       setHoveredTable(null);
     }
 
@@ -109,6 +112,13 @@ export default function TableHoverActionsPlugin({ anchor }: { anchor: HTMLElemen
 
       updateTimeoutId = setTimeout(() => {
         updateTimeoutId = undefined;
+
+        if (document.body.hasAttribute('data-table-resizing')) {
+          setHoveredTable(null);
+
+          return;
+        }
+
         updateFromPoint(lastPointerPos.x, lastPointerPos.y);
       }, 0);
     });

--- a/src/components/editor/plugins/toolbar-editor-plugin.tsx
+++ b/src/components/editor/plugins/toolbar-editor-plugin.tsx
@@ -11,8 +11,10 @@ import {
   UNDO_COMMAND,
   HISTORIC_TAG,
   $getSelection,
+  $setSelection,
   $addUpdateTag,
   $isRangeSelection,
+  type BaseSelection,
   FORMAT_TEXT_COMMAND,
   type TextFormatType,
   FORMAT_ELEMENT_COMMAND,
@@ -39,6 +41,7 @@ import {
   BaselineIcon,
   DownloadIcon,
   UnderlineIcon,
+  PaintRollerIcon,
   ChevronDownIcon,
   TextInitialIcon,
   PaintBucketIcon,
@@ -101,6 +104,7 @@ import {
   formatNumberedList,
 } from '@/lib/utils/editor-helpers';
 import getErrorMessage from '@/lib/utils/get-error-message';
+import $getSelectedTableCells from '@/lib/utils/get-selected-table-cells';
 
 const FONT_FAMILIES = [
   'Arial',
@@ -131,8 +135,11 @@ export default function ToolbarEditorPlugin() {
   const [isListsDropdownOpen, setIsListsDropdownOpen] = React.useState(false);
   const [isTextFormatDropdownOpen, setIsTextFormatDropdownOpen] = React.useState(false);
   const [isTableSizePickerOpen, setIsTableSizePickerOpen] = React.useState(false);
+  const [isCellBackgroundColorPickerOpen, setIsCellBackgroundColorPickerOpen] = React.useState(false);
   const [fontColor, setFontColor] = React.useState('');
   const [backgroundColor, setBackgroundColor] = React.useState('');
+  const [cellBackgroundColor, setCellBackgroundColor] = React.useState('');
+  const cachedTableSelectionRef = React.useRef<BaseSelection | null>(null);
   const [isSavingActiveDocument, setIsSavingActiveDocument] = React.useState(false);
   useEditorToolbarSync();
 
@@ -268,6 +275,43 @@ export default function ToolbarEditorPlugin() {
   React.useEffect(() => {
     setBackgroundColor(toolbarState.backgroundColor);
   }, [toolbarState.backgroundColor]);
+
+  React.useEffect(() => {
+    setCellBackgroundColor(toolbarState.tableCellBackgroundColor);
+  }, [toolbarState.tableCellBackgroundColor]);
+
+  function handleCellBackgroundColorOpenChange(open: boolean) {
+    if (open) {
+      editor.read('latest', () => {
+        const selection = $getSelection();
+
+        cachedTableSelectionRef.current = selection ? selection.clone() : null;
+      });
+      setIsFontColorPickerOpen(false);
+      setIsBackgroundColorPickerOpen(false);
+    }
+
+    setIsCellBackgroundColorPickerOpen(open);
+  }
+
+  function handleCellBackgroundColorChange(value: string, skipHistoryStack: boolean) {
+    setCellBackgroundColor(value);
+    editor.update(() => {
+      if (skipHistoryStack) {
+        $addUpdateTag(HISTORIC_TAG);
+      }
+
+      const cached = cachedTableSelectionRef.current;
+
+      if (cached) {
+        $setSelection(cached.clone());
+      }
+
+      $getSelectedTableCells($getSelection()).forEach((cell) => {
+        cell.setBackgroundColor(value);
+      });
+    });
+  }
 
   const applyFontColor = React.useCallback(() => {
     setIsFontColorPickerOpen(false);
@@ -854,6 +898,56 @@ export default function ToolbarEditorPlugin() {
             </div>
           </PopoverContent>
         </Popover>
+
+        {toolbarState.isTableCell && (
+          <Popover open={isCellBackgroundColorPickerOpen} onOpenChange={handleCellBackgroundColorOpenChange}>
+            <PopoverTrigger asChild>
+              <Button
+                size="sm"
+                variant="secondary"
+                aria-label="Cell background color"
+                className="shrink-0 gap-0 space-x-2"
+              >
+                <div
+                  className="flex size-4 items-center justify-center rounded-md"
+                  style={{
+                    color: cellBackgroundColor
+                      ? Color(cellBackgroundColor).alpha(0.8).string()
+                      : 'var(--text-foreground)',
+                  }}
+                >
+                  <PaintRollerIcon strokeWidth="2.5px" />
+                </div>
+                <ChevronDownIcon />
+              </Button>
+            </PopoverTrigger>
+            <PopoverContent asChild>
+              <div className="w-[305px] space-y-4">
+                <div className="text-muted-foreground flex items-center justify-between">
+                  <p className="text-sm">Cell background color</p>
+                  <Button
+                    size="xs"
+                    variant="ghost"
+                    onClick={() => {
+                      setIsCellBackgroundColorPickerOpen(false);
+                    }}
+                  >
+                    <XIcon className="size-4" />
+                  </Button>
+                </div>
+                <EditorColorPicker value={cellBackgroundColor} onChange={handleCellBackgroundColorChange} />
+                <Button
+                  className="w-full"
+                  onClick={() => {
+                    setIsCellBackgroundColorPickerOpen(false);
+                  }}
+                >
+                  <span>Apply</span>
+                </Button>
+              </div>
+            </PopoverContent>
+          </Popover>
+        )}
 
         <Separator orientation="vertical" className="h-6! shrink-0 self-center justify-self-center" />
 

--- a/src/components/editor/plugins/toolbar-editor-plugin.tsx
+++ b/src/components/editor/plugins/toolbar-editor-plugin.tsx
@@ -3,20 +3,19 @@ import { TOGGLE_LINK_COMMAND } from '@lexical/link';
 import { $convertToMarkdownString, $convertFromMarkdownString } from '@lexical/markdown';
 import { useLexicalComposerContext } from '@lexical/react/LexicalComposerContext';
 import { $patchStyleText } from '@lexical/selection';
-import { INSERT_TABLE_COMMAND } from '@lexical/table';
+import { $isTableCellNode, INSERT_TABLE_COMMAND } from '@lexical/table';
 import * as Sentry from '@sentry/nextjs';
-import Color from 'color';
 import {
   REDO_COMMAND,
   UNDO_COMMAND,
   HISTORIC_TAG,
+  $getNodeByKey,
   $getSelection,
-  $setSelection,
   $addUpdateTag,
   $isRangeSelection,
-  type BaseSelection,
   FORMAT_TEXT_COMMAND,
   type TextFormatType,
+  SKIP_DOM_SELECTION_TAG,
   FORMAT_ELEMENT_COMMAND,
   INDENT_CONTENT_COMMAND,
   COMMAND_PRIORITY_NORMAL,
@@ -139,7 +138,8 @@ export default function ToolbarEditorPlugin() {
   const [fontColor, setFontColor] = React.useState('');
   const [backgroundColor, setBackgroundColor] = React.useState('');
   const [cellBackgroundColor, setCellBackgroundColor] = React.useState('');
-  const cachedTableSelectionRef = React.useRef<BaseSelection | null>(null);
+  const targetCellKeysRef = React.useRef<string[]>([]);
+  const previousCellBackgroundsRef = React.useRef(new Map<string, null | string>());
   const [isSavingActiveDocument, setIsSavingActiveDocument] = React.useState(false);
   useEditorToolbarSync();
 
@@ -280,37 +280,105 @@ export default function ToolbarEditorPlugin() {
     setCellBackgroundColor(toolbarState.tableCellBackgroundColor);
   }, [toolbarState.tableCellBackgroundColor]);
 
-  function handleCellBackgroundColorOpenChange(open: boolean) {
-    if (open) {
-      editor.read('latest', () => {
-        const selection = $getSelection();
+  const applyCellBackgroundEmphasis = React.useCallback(() => {
+    targetCellKeysRef.current.forEach((key) => {
+      const element = editor.getElementByKey(key);
 
-        cachedTableSelectionRef.current = selection ? selection.clone() : null;
-      });
-      setIsFontColorPickerOpen(false);
-      setIsBackgroundColorPickerOpen(false);
+      if (element) {
+        element.style.outline = '2px dashed var(--primary)';
+        element.style.outlineOffset = '-2px';
+      }
+    });
+  }, [editor]);
+
+  const clearCellBackgroundEmphasis = React.useCallback(() => {
+    targetCellKeysRef.current.forEach((key) => {
+      const element = editor.getElementByKey(key);
+
+      if (element) {
+        element.style.outline = '';
+        element.style.outlineOffset = '';
+      }
+    });
+  }, [editor]);
+
+  const cancelCellBackgroundColor = React.useCallback(() => {
+    editor.update(
+      () => {
+        $addUpdateTag(HISTORIC_TAG);
+        $addUpdateTag(SKIP_DOM_SELECTION_TAG);
+        previousCellBackgroundsRef.current.forEach((background, key) => {
+          const cell = $getNodeByKey(key);
+
+          if ($isTableCellNode(cell)) {
+            cell.setBackgroundColor(background);
+          }
+        });
+      },
+      { onUpdate: clearCellBackgroundEmphasis }
+    );
+    setIsCellBackgroundColorPickerOpen(false);
+  }, [editor, clearCellBackgroundEmphasis]);
+
+  React.useEffect(() => {
+    if (!toolbarState.isTableCell && isCellBackgroundColorPickerOpen) {
+      cancelCellBackgroundColor();
+    }
+  }, [toolbarState.isTableCell, isCellBackgroundColorPickerOpen, cancelCellBackgroundColor]);
+
+  function handleCellBackgroundColorOpenChange(open: boolean) {
+    if (!open) {
+      cancelCellBackgroundColor();
+
+      return;
     }
 
-    setIsCellBackgroundColorPickerOpen(open);
+    editor.read('latest', () => {
+      const cells = $getSelectedTableCells($getSelection());
+
+      targetCellKeysRef.current = cells.map((cell) => {
+        return cell.getKey();
+      });
+      previousCellBackgroundsRef.current = new Map(
+        cells.map((cell) => {
+          return [cell.getKey(), cell.getBackgroundColor()];
+        })
+      );
+    });
+    applyCellBackgroundEmphasis();
+    setIsFontColorPickerOpen(false);
+    setIsBackgroundColorPickerOpen(false);
+    setIsCellBackgroundColorPickerOpen(true);
   }
 
   function handleCellBackgroundColorChange(value: string, skipHistoryStack: boolean) {
+    if (!isCellBackgroundColorPickerOpen || (!skipHistoryStack && value === cellBackgroundColor)) {
+      return;
+    }
+
     setCellBackgroundColor(value);
-    editor.update(() => {
-      if (skipHistoryStack) {
-        $addUpdateTag(HISTORIC_TAG);
-      }
+    editor.update(
+      () => {
+        if (skipHistoryStack) {
+          $addUpdateTag(HISTORIC_TAG);
+        }
 
-      const cached = cachedTableSelectionRef.current;
+        $addUpdateTag(SKIP_DOM_SELECTION_TAG);
+        targetCellKeysRef.current.forEach((key) => {
+          const cell = $getNodeByKey(key);
 
-      if (cached) {
-        $setSelection(cached.clone());
-      }
+          if ($isTableCellNode(cell)) {
+            cell.setBackgroundColor(value);
+          }
+        });
+      },
+      { onUpdate: applyCellBackgroundEmphasis }
+    );
+  }
 
-      $getSelectedTableCells($getSelection()).forEach((cell) => {
-        cell.setBackgroundColor(value);
-      });
-    });
+  function applyCellBackgroundColor() {
+    clearCellBackgroundEmphasis();
+    setIsCellBackgroundColorPickerOpen(false);
   }
 
   const applyFontColor = React.useCallback(() => {
@@ -799,15 +867,8 @@ export default function ToolbarEditorPlugin() {
 
         <Popover open={isFontColorPickerOpen} onOpenChange={handleFontColorOpenChange}>
           <PopoverTrigger asChild>
-            <Button size="sm" variant="secondary" className="shrink-0 gap-0 space-x-2">
-              <div
-                className="flex size-4 items-center justify-center rounded-md"
-                style={{
-                  color: fontColor ? Color(fontColor).alpha(0.8).string() : 'var(--text-foreground)',
-                }}
-              >
-                <BaselineIcon strokeWidth="2.5px" />
-              </div>
+            <Button size="sm" variant="secondary" aria-label="Font color" className="shrink-0 gap-0 space-x-2">
+              <BaselineIcon strokeWidth="2.5px" />
               <ChevronDownIcon />
             </Button>
           </PopoverTrigger>
@@ -850,15 +911,8 @@ export default function ToolbarEditorPlugin() {
 
         <Popover open={isBackgroundColorPickerOpen} onOpenChange={handleBackgroundColorOpenChange}>
           <PopoverTrigger asChild>
-            <Button size="sm" variant="secondary" className="shrink-0 gap-0 space-x-2">
-              <div
-                className="flex size-4 items-center justify-center rounded-md"
-                style={{
-                  color: backgroundColor ? Color(backgroundColor).alpha(0.8).string() : 'var(--text-foreground)',
-                }}
-              >
-                <PaintBucketIcon strokeWidth="2.5px" />
-              </div>
+            <Button size="sm" variant="secondary" aria-label="Background color" className="shrink-0 gap-0 space-x-2">
+              <PaintBucketIcon strokeWidth="2.5px" />
               <ChevronDownIcon />
             </Button>
           </PopoverTrigger>
@@ -908,16 +962,7 @@ export default function ToolbarEditorPlugin() {
                 aria-label="Cell background color"
                 className="shrink-0 gap-0 space-x-2"
               >
-                <div
-                  className="flex size-4 items-center justify-center rounded-md"
-                  style={{
-                    color: cellBackgroundColor
-                      ? Color(cellBackgroundColor).alpha(0.8).string()
-                      : 'var(--text-foreground)',
-                  }}
-                >
-                  <PaintRollerIcon strokeWidth="2.5px" />
-                </div>
+                <PaintRollerIcon strokeWidth="2.5px" />
                 <ChevronDownIcon />
               </Button>
             </PopoverTrigger>
@@ -925,23 +970,16 @@ export default function ToolbarEditorPlugin() {
               <div className="w-[305px] space-y-4">
                 <div className="text-muted-foreground flex items-center justify-between">
                   <p className="text-sm">Cell background color</p>
-                  <Button
-                    size="xs"
-                    variant="ghost"
-                    onClick={() => {
-                      setIsCellBackgroundColorPickerOpen(false);
-                    }}
-                  >
+                  <Button size="xs" variant="ghost" onClick={cancelCellBackgroundColor}>
                     <XIcon className="size-4" />
                   </Button>
                 </div>
                 <EditorColorPicker value={cellBackgroundColor} onChange={handleCellBackgroundColorChange} />
-                <Button
-                  className="w-full"
-                  onClick={() => {
-                    setIsCellBackgroundColorPickerOpen(false);
-                  }}
-                >
+                <Button variant="outline" className="w-full" onClick={cancelCellBackgroundColor}>
+                  <div className="rounded border border-current px-1 py-0.5 text-xs">Esc</div>
+                  <span>Cancel</span>
+                </Button>
+                <Button className="w-full" onClick={applyCellBackgroundColor}>
                   <span>Apply</span>
                 </Button>
               </div>

--- a/src/lib/constants/initial-editor-toolbar-state.ts
+++ b/src/lib/constants/initial-editor-toolbar-state.ts
@@ -40,9 +40,11 @@ const INITIAL_TOOLBAR_STATE = {
   isStrikethrough: false,
   isSubscript: false,
   isSuperscript: false,
+  isTableCell: false,
   isUnderline: false,
   isUppercase: false,
   linkUrl: '',
+  tableCellBackgroundColor: '',
 };
 
 export default INITIAL_TOOLBAR_STATE;

--- a/src/lib/hooks/use-editor-toolbar-sync.ts
+++ b/src/lib/hooks/use-editor-toolbar-sync.ts
@@ -3,7 +3,7 @@ import { $isListNode } from '@lexical/list';
 import { useLexicalComposerContext } from '@lexical/react/LexicalComposerContext';
 import { $isHeadingNode } from '@lexical/rich-text';
 import { $getSelectionStyleValueForProperty } from '@lexical/selection';
-import { $isTableSelection } from '@lexical/table';
+import { $isTableSelection, $getTableCellNodeFromLexicalNode } from '@lexical/table';
 import { mergeRegister } from '@lexical/utils';
 import {
   $getSelection,
@@ -183,6 +183,15 @@ export default function useEditorToolbarSync() {
           updateToolbarState('blockType', blockType as keyof typeof blockTypeToBlockName);
         }
       }
+    }
+
+    if ($isRangeSelection(selection) || $isTableSelection(selection)) {
+      const tableCellNode = $getTableCellNodeFromLexicalNode(selection.anchor.getNode());
+
+      updateToolbarState('isTableCell', tableCellNode !== null);
+      updateToolbarState('tableCellBackgroundColor', tableCellNode?.getBackgroundColor() || currentBackgroundColor);
+    } else {
+      updateToolbarState('isTableCell', false);
     }
 
     if ($isRangeSelection(selection) || $isTableSelection(selection)) {

--- a/src/lib/utils/get-selected-table-cells.ts
+++ b/src/lib/utils/get-selected-table-cells.ts
@@ -1,0 +1,24 @@
+import { $getNodeTriplet, $isTableCellNode, $isTableSelection, type TableCellNode } from '@lexical/table';
+import { $isRangeSelection, type BaseSelection } from 'lexical';
+
+export default function $getSelectedTableCells(selection: BaseSelection | null) {
+  const cells = new Set<TableCellNode>();
+
+  if ($isRangeSelection(selection) || $isTableSelection(selection)) {
+    const [anchorCell] = $getNodeTriplet(selection.anchor);
+
+    if ($isTableCellNode(anchorCell)) {
+      cells.add(anchorCell);
+    }
+
+    if ($isTableSelection(selection)) {
+      selection.getNodes().forEach((node) => {
+        if ($isTableCellNode(node)) {
+          cells.add(node);
+        }
+      });
+    }
+  }
+
+  return [...cells];
+}


### PR DESCRIPTION
## Description

Adds toolbar support for table-cell background color, including state sync, selection caching, and a dedicated picker in the editor toolbar. Also extracts selected table-cell lookup into a shared utility and keeps the hover menu responsive during editor updates.

## Type of Change

- [ ] Bug fix
- [x] New feature
- [ ] Documentation update
- [ ] Refactoring
- [ ] Performance improvement
- [ ] Test addition or update
- [ ] Build process or tooling change
- [ ] Code style or formatting change
- [ ] Other (please describe)

[//]: # 'Uncomment the following lines if your change is related to an issue'
[//]: # '## Related Issues (if any)'
[//]: #
[//]: # 'Fixes #(issue number)'

## Checklist

- [x] My code follows the project's style guidelines
- [x] I've tested my changes locally
- [ ] I've updated documentation if needed


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added table cell background color controls in the editor toolbar.
  * Table cells can now be highlighted while the color picker is open, with changes applied directly to selected cells.

* **Bug Fixes**
  * Improved table hover and selection handling for more reliable toolbar and menu behavior.
  * Toolbar state now updates more accurately when switching between table and non-table selections.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->