### PR TITLE
feat(editor): add markdown import and paste features

### DIFF
--- a/src/components/custom/import-markdown-dialog.tsx
+++ b/src/components/custom/import-markdown-dialog.tsx
@@ -1,0 +1,134 @@
+'use client';
+
+import * as Sentry from '@sentry/nextjs';
+import { FileIcon, UploadIcon, LoaderCircleIcon } from 'lucide-react';
+import posthog from 'posthog-js';
+import * as React from 'react';
+import { toast } from 'sonner';
+
+import { Button } from '@/components/ui/button';
+import { Dialog, DialogClose, DialogTitle, DialogFooter, DialogHeader, DialogContent } from '@/components/ui/dialog';
+import { createDocument } from '@/lib/actions/document.actions';
+import convertMarkdownToEditorState from '@/lib/utils/convert-markdown-to-editor-state';
+import getErrorMessage from '@/lib/utils/get-error-message';
+
+type ImportMarkdownDialogProps = {
+  open: boolean;
+  parentFolderId?: string | null;
+  onOpenChange: (open: boolean) => void;
+};
+
+export default function ImportMarkdownDialog({ onOpenChange, open, parentFolderId }: ImportMarkdownDialogProps) {
+  const [file, setFile] = React.useState<File | null>(null);
+  const [isImporting, setIsImporting] = React.useState(false);
+  const fileInputRef = React.useRef<HTMLInputElement>(null);
+
+  function resetState() {
+    setFile(null);
+    setIsImporting(false);
+
+    if (fileInputRef.current) {
+      fileInputRef.current.value = '';
+    }
+  }
+
+  function handleOpenChange(nextOpen: boolean) {
+    if (!nextOpen) {
+      resetState();
+    }
+
+    onOpenChange(nextOpen);
+  }
+
+  function handleFileChange(event: React.ChangeEvent<HTMLInputElement>) {
+    setFile(event.target.files?.[0] ?? null);
+  }
+
+  async function handleConfirm() {
+    if (!file) {
+      return;
+    }
+
+    try {
+      setIsImporting(true);
+
+      const content = await file.text();
+      const editorState = convertMarkdownToEditorState(content);
+      const title = file.name.replace(/\.(md|markdown)$/i, '');
+      const { id } = await createDocument({
+        content: editorState,
+        folderId: parentFolderId ?? null,
+        title,
+      });
+
+      posthog.capture('document_imported_from_markdown', { documentId: id });
+      toast.success(`Imported "${file.name}" as a new document`);
+      handleOpenChange(false);
+    } catch (error) {
+      Sentry.captureException(error);
+      console.error('Error importing markdown file: ', error);
+      toast.error('Error importing markdown file', {
+        description: getErrorMessage(error),
+      });
+    } finally {
+      setIsImporting(false);
+    }
+  }
+
+  return (
+    <Dialog open={open} onOpenChange={handleOpenChange}>
+      {open && (
+        <DialogContent className="sm:max-w-[425px]">
+          <DialogHeader>
+            <DialogTitle>Import Markdown</DialogTitle>
+          </DialogHeader>
+
+          <input
+            type="file"
+            className="hidden"
+            ref={fileInputRef}
+            onChange={handleFileChange}
+            accept=".md,.markdown,text/markdown"
+          />
+
+          <button
+            type="button"
+            onClick={() => {
+              fileInputRef.current?.click();
+            }}
+            className="border-input hover:bg-accent hover:text-accent-foreground flex flex-col items-center justify-center gap-2 rounded-md border border-dashed px-6 py-10 text-center transition-colors"
+          >
+            {file ? (
+              <>
+                <FileIcon className="text-muted-foreground size-6" />
+                <span className="text-sm font-medium">{file.name}</span>
+                <span className="text-muted-foreground text-xs">Click to choose a different file</span>
+              </>
+            ) : (
+              <>
+                <UploadIcon className="text-muted-foreground size-6" />
+                <span className="text-sm font-medium">Select a .md file</span>
+                <span className="text-muted-foreground text-xs">This will create a new document</span>
+              </>
+            )}
+          </button>
+
+          <DialogFooter>
+            <DialogClose asChild>
+              <Button variant="outline">Cancel</Button>
+            </DialogClose>
+            <Button
+              disabled={!file || isImporting}
+              onClick={() => {
+                void handleConfirm();
+              }}
+            >
+              {isImporting && <LoaderCircleIcon className="mr-2 animate-spin" />}
+              Import
+            </Button>
+          </DialogFooter>
+        </DialogContent>
+      )}
+    </Dialog>
+  );
+}

--- a/src/components/custom/paste-markdown-dialog.tsx
+++ b/src/components/custom/paste-markdown-dialog.tsx
@@ -1,0 +1,154 @@
+'use client';
+
+import * as Sentry from '@sentry/nextjs';
+import { LoaderCircleIcon, ClipboardPasteIcon } from 'lucide-react';
+import posthog from 'posthog-js';
+import * as React from 'react';
+import { toast } from 'sonner';
+
+import { Button } from '@/components/ui/button';
+import { Dialog, DialogClose, DialogTitle, DialogFooter, DialogHeader, DialogContent } from '@/components/ui/dialog';
+import { Input } from '@/components/ui/input';
+import { createDocument } from '@/lib/actions/document.actions';
+import convertMarkdownToEditorState from '@/lib/utils/convert-markdown-to-editor-state';
+import getErrorMessage from '@/lib/utils/get-error-message';
+
+type PasteMarkdownDialogProps = {
+  open: boolean;
+  parentFolderId?: string | null;
+  onOpenChange: (open: boolean) => void;
+};
+
+export default function PasteMarkdownDialog({ onOpenChange, open, parentFolderId }: PasteMarkdownDialogProps) {
+  const [content, setContent] = React.useState('');
+  const [title, setTitle] = React.useState('');
+  const [isOverflowing, setIsOverflowing] = React.useState(false);
+  const [isImporting, setIsImporting] = React.useState(false);
+  const previewRef = React.useRef<HTMLDivElement>(null);
+  const pasteTargetRef = React.useRef<HTMLDivElement>(null);
+
+  function resetState() {
+    setContent('');
+    setTitle('');
+    setIsOverflowing(false);
+    setIsImporting(false);
+  }
+
+  function handleOpenChange(nextOpen: boolean) {
+    if (!nextOpen) {
+      resetState();
+    }
+
+    onOpenChange(nextOpen);
+  }
+
+  React.useEffect(() => {
+    if (open) {
+      pasteTargetRef.current?.focus();
+    }
+  }, [open]);
+
+  React.useLayoutEffect(() => {
+    const element = previewRef.current;
+
+    if (!element) {
+      setIsOverflowing(false);
+
+      return;
+    }
+
+    setIsOverflowing(element.scrollHeight > element.clientHeight);
+  }, [content]);
+
+  function handlePaste(event: React.ClipboardEvent<HTMLDivElement>) {
+    event.preventDefault();
+    setContent(event.clipboardData.getData('text/plain'));
+  }
+
+  async function handleConfirm() {
+    if (!content) {
+      return;
+    }
+
+    try {
+      setIsImporting(true);
+
+      const editorState = convertMarkdownToEditorState(content);
+      const { id } = await createDocument({
+        content: editorState,
+        folderId: parentFolderId ?? null,
+        title: title.trim() || 'Untitled Document',
+      });
+
+      posthog.capture('document_imported_from_markdown', { documentId: id });
+      toast.success('Created a new document from pasted markdown');
+      handleOpenChange(false);
+    } catch (error) {
+      Sentry.captureException(error);
+      console.error('Error creating document from pasted markdown: ', error);
+      toast.error('Error creating document from pasted markdown', {
+        description: getErrorMessage(error),
+      });
+    } finally {
+      setIsImporting(false);
+    }
+  }
+
+  return (
+    <Dialog open={open} onOpenChange={handleOpenChange}>
+      {open && (
+        <DialogContent className="sm:max-w-[425px]">
+          <DialogHeader>
+            <DialogTitle>Paste Markdown</DialogTitle>
+          </DialogHeader>
+
+          <Input
+            value={title}
+            placeholder="Untitled Document"
+            onChange={(event) => {
+              setTitle(event.target.value);
+            }}
+          />
+
+          <div className="relative">
+            <div
+              tabIndex={0}
+              ref={pasteTargetRef}
+              onPaste={handlePaste}
+              className="border-input focus-visible:border-ring focus-visible:ring-ring/50 rounded-md border outline-none focus-visible:ring-[3px]"
+            >
+              <div ref={previewRef} className="max-h-56 overflow-y-auto p-3">
+                {content ? (
+                  <pre className="font-mono text-xs whitespace-pre-wrap">{content}</pre>
+                ) : (
+                  <div className="text-muted-foreground flex flex-col items-center justify-center gap-2 py-8 text-center text-sm">
+                    <ClipboardPasteIcon className="size-6" />
+                    Press ⌘V / Ctrl+V to paste markdown
+                  </div>
+                )}
+              </div>
+            </div>
+            {isOverflowing && (
+              <div className="from-background pointer-events-none absolute inset-x-0 bottom-0 h-12 rounded-b-md bg-gradient-to-t to-transparent" />
+            )}
+          </div>
+
+          <DialogFooter>
+            <DialogClose asChild>
+              <Button variant="outline">Cancel</Button>
+            </DialogClose>
+            <Button
+              disabled={!content || isImporting}
+              onClick={() => {
+                void handleConfirm();
+              }}
+            >
+              {isImporting && <LoaderCircleIcon className="mr-2 animate-spin" />}
+              Create Document
+            </Button>
+          </DialogFooter>
+        </DialogContent>
+      )}
+    </Dialog>
+  );
+}

--- a/src/components/editor/plugins/toolbar-editor-plugin.tsx
+++ b/src/components/editor/plugins/toolbar-editor-plugin.tsx
@@ -1,11 +1,12 @@
 import { useUser } from '@clerk/nextjs';
 import { TOGGLE_LINK_COMMAND } from '@lexical/link';
-import { $convertToMarkdownString, $convertFromMarkdownString } from '@lexical/markdown';
+import { $convertToMarkdownString } from '@lexical/markdown';
 import { useLexicalComposerContext } from '@lexical/react/LexicalComposerContext';
 import { $patchStyleText } from '@lexical/selection';
 import { $isTableCellNode, INSERT_TABLE_COMMAND } from '@lexical/table';
 import * as Sentry from '@sentry/nextjs';
 import {
+  $getRoot,
   REDO_COMMAND,
   UNDO_COMMAND,
   HISTORIC_TAG,
@@ -30,15 +31,17 @@ import {
   RedoIcon,
   LinkIcon,
   SaveIcon,
+  CopyIcon,
   QuoteIcon,
   TableIcon,
   IndentIcon,
   ItalicIcon,
   EraserIcon,
-  UploadIcon,
   HeadingIcon,
   BaselineIcon,
   DownloadIcon,
+  FileTextIcon,
+  FileDownIcon,
   UnderlineIcon,
   PaintRollerIcon,
   ChevronDownIcon,
@@ -133,6 +136,7 @@ export default function ToolbarEditorPlugin() {
   const [isHeadingsDropdownOpen, setIsHeadingsDropdownOpen] = React.useState(false);
   const [isListsDropdownOpen, setIsListsDropdownOpen] = React.useState(false);
   const [isTextFormatDropdownOpen, setIsTextFormatDropdownOpen] = React.useState(false);
+  const [isExportDropdownOpen, setIsExportDropdownOpen] = React.useState(false);
   const [isTableSizePickerOpen, setIsTableSizePickerOpen] = React.useState(false);
   const [isCellBackgroundColorPickerOpen, setIsCellBackgroundColorPickerOpen] = React.useState(false);
   const [fontColor, setFontColor] = React.useState('');
@@ -475,8 +479,6 @@ export default function ToolbarEditorPlugin() {
     }
   }, [activeDocument, editor, openDocumentDialog]);
 
-  const markdownFileInputRef = React.useRef<HTMLInputElement>(null);
-
   const downloadEditorMarkdown = React.useCallback(() => {
     editor.read(() => {
       const markdown = $convertToMarkdownString(ENHANCED_LEXICAL_TRANSFORMERS, undefined, true);
@@ -493,36 +495,37 @@ export default function ToolbarEditorPlugin() {
     });
   }, [editor, activeDocument?.title]);
 
-  const importMarkdown = React.useCallback(
-    (event: React.ChangeEvent<HTMLInputElement>) => {
-      const file = event.target.files?.[0];
+  const copyEditorMarkdown = React.useCallback(() => {
+    editor.read(() => {
+      const markdown = $convertToMarkdownString(ENHANCED_LEXICAL_TRANSFORMERS, undefined, true);
 
-      if (!file) {
-        return;
-      }
-
-      const reader = new FileReader();
-
-      reader.onload = (e) => {
-        const content = e.target?.result as string;
-
-        editor.update(() => {
-          $convertFromMarkdownString(content, ENHANCED_LEXICAL_TRANSFORMERS, undefined, true);
+      navigator.clipboard
+        .writeText(markdown)
+        .then(() => {
+          toast.success('Copied as Markdown');
+        })
+        .catch((error: unknown) => {
+          Sentry.captureException(error);
+          toast.error('Failed to copy', { description: getErrorMessage(error) });
         });
+    });
+  }, [editor]);
 
-        toast.success(`Imported "${file.name}" successfully`);
-      };
+  const copyEditorPlainText = React.useCallback(() => {
+    editor.read(() => {
+      const text = $getRoot().getTextContent();
 
-      reader.onerror = () => {
-        toast.error('Failed to read the file');
-      };
-
-      reader.readAsText(file);
-
-      event.target.value = '';
-    },
-    [editor]
-  );
+      navigator.clipboard
+        .writeText(text)
+        .then(() => {
+          toast.success('Copied as plain text');
+        })
+        .catch((error: unknown) => {
+          Sentry.captureException(error);
+          toast.error('Failed to copy', { description: getErrorMessage(error) });
+        });
+    });
+  }, [editor]);
 
   return (
     <TooltipProvider>
@@ -1111,34 +1114,38 @@ export default function ToolbarEditorPlugin() {
 
         <Separator orientation="vertical" className="h-6! shrink-0 self-center justify-self-center" />
 
-        <input
-          type="file"
-          className="hidden"
-          onChange={importMarkdown}
-          ref={markdownFileInputRef}
-          accept=".md,.markdown,text/markdown"
-        />
-
-        <ButtonGroup>
-          <TooltipButton
-            {...tooltipGroup.getTooltipProps()}
-            variant="ghost"
-            tooltip="Import Markdown"
-            onClick={() => {
-              markdownFileInputRef.current?.click();
-            }}
-          >
-            <UploadIcon />
-          </TooltipButton>
-          <TooltipButton
-            {...tooltipGroup.getTooltipProps()}
-            variant="ghost"
-            tooltip="Export as Markdown"
-            onClick={downloadEditorMarkdown}
-          >
-            <DownloadIcon />
-          </TooltipButton>
-        </ButtonGroup>
+        <DropdownMenu open={isExportDropdownOpen} onOpenChange={setIsExportDropdownOpen}>
+          <Tooltip delayDuration={tooltipGroup.getTooltipProps().delayDuration}>
+            <TooltipTrigger asChild onMouseEnter={tooltipGroup.getTooltipProps().onMouseEnter}>
+              <DropdownMenuTrigger asChild>
+                <Button
+                  variant="secondary"
+                  aria-label="Export"
+                  className="shrink-0"
+                  disabled={isSavingActiveDocument || isEditorEmpty}
+                >
+                  <FileDownIcon />
+                  Export
+                </Button>
+              </DropdownMenuTrigger>
+            </TooltipTrigger>
+            <TooltipContent>Export</TooltipContent>
+          </Tooltip>
+          <DropdownMenuContent>
+            <DropdownMenuItem className="space-x-2" onClick={downloadEditorMarkdown}>
+              <DownloadIcon />
+              Download as Markdown
+            </DropdownMenuItem>
+            <DropdownMenuItem className="space-x-2" onClick={copyEditorMarkdown}>
+              <CopyIcon />
+              Copy as Markdown
+            </DropdownMenuItem>
+            <DropdownMenuItem className="space-x-2" onClick={copyEditorPlainText}>
+              <FileTextIcon />
+              Copy as Plain Text
+            </DropdownMenuItem>
+          </DropdownMenuContent>
+        </DropdownMenu>
       </div>
     </TooltipProvider>
   );

--- a/src/components/layout/sidebar-directory-tree.tsx
+++ b/src/components/layout/sidebar-directory-tree.tsx
@@ -16,6 +16,7 @@ import {
 import {
   FileIcon,
   TrashIcon,
+  UploadIcon,
   FolderIcon,
   FilePlusIcon,
   Settings2Icon,
@@ -24,11 +25,14 @@ import {
   FolderPlusIcon,
   FolderInputIcon,
   LoaderCircleIcon,
+  ClipboardPasteIcon,
   EllipsisVerticalIcon,
 } from 'lucide-react';
 import Link from 'next/link';
 import * as React from 'react';
 
+import ImportMarkdownDialog from '@/components/custom/import-markdown-dialog';
+import PasteMarkdownDialog from '@/components/custom/paste-markdown-dialog';
 import SidebarDocumentLinkButton from '@/components/layout/sidebar-document-link-button';
 import { useDocument } from '@/components/providers/document-provider';
 import { useSidebar } from '@/components/providers/sidebar-provider';
@@ -354,6 +358,8 @@ function SidebarFolderItem({ folder }: { folder: FolderNode }) {
     setFolderIdInteractedWith,
     toggleFolderExpansion,
   } = useDocument();
+  const [isImportMarkdownDialogOpen, setIsImportMarkdownDialogOpen] = React.useState(false);
+  const [isPasteMarkdownDialogOpen, setIsPasteMarkdownDialogOpen] = React.useState(false);
 
   const isExpanded = expandedFolderIds.has(folder.id);
   const isBeingRemoved = folderIdBeingRemoved === folder.id;
@@ -518,6 +524,32 @@ function SidebarFolderItem({ folder }: { folder: FolderNode }) {
                 <FolderPlusIcon />
                 New folder inside
               </DropdownMenuItem>
+              <DropdownMenuItem
+                className="flex-col items-start gap-0.5 space-x-0"
+                onClick={() => {
+                  setIsImportMarkdownDialogOpen(true);
+                }}
+              >
+                <div className="flex items-center gap-2">
+                  <UploadIcon />
+                  Import Markdown
+                </div>
+                <p className="text-muted-foreground pl-6 text-xs">Select a .md file to create a new document inside</p>
+              </DropdownMenuItem>
+              <DropdownMenuItem
+                className="flex-col items-start gap-0.5 space-x-0"
+                onClick={() => {
+                  setIsPasteMarkdownDialogOpen(true);
+                }}
+              >
+                <div className="flex items-center gap-2">
+                  <ClipboardPasteIcon />
+                  Paste Markdown
+                </div>
+                <p className="text-muted-foreground pl-6 text-xs">
+                  Paste markdown text to create a new document inside
+                </p>
+              </DropdownMenuItem>
               <DropdownMenuSeparator />
               <DropdownMenuItem
                 variant="destructive"
@@ -532,6 +564,17 @@ function SidebarFolderItem({ folder }: { folder: FolderNode }) {
             </DropdownMenuContent>
           </DropdownMenu>
         </div>
+
+        <ImportMarkdownDialog
+          parentFolderId={folder.id}
+          open={isImportMarkdownDialogOpen}
+          onOpenChange={setIsImportMarkdownDialogOpen}
+        />
+        <PasteMarkdownDialog
+          parentFolderId={folder.id}
+          open={isPasteMarkdownDialogOpen}
+          onOpenChange={setIsPasteMarkdownDialogOpen}
+        />
 
         <CollapsibleContent>
           {hasChildren ? (

--- a/src/components/layout/sidebar.tsx
+++ b/src/components/layout/sidebar.tsx
@@ -6,10 +6,12 @@ import {
   KeyIcon,
   MoonIcon,
   LogInIcon,
+  UploadIcon,
   MonitorIcon,
   FolderPlusIcon,
   ChevronDownIcon,
   ExternalLinkIcon,
+  ClipboardPasteIcon,
   FilePlusCornerIcon,
   PanelLeftCloseIcon,
   PanelRightCloseIcon,
@@ -20,6 +22,8 @@ import { useSelectedLayoutSegment } from 'next/navigation';
 import posthog from 'posthog-js';
 import * as React from 'react';
 
+import ImportMarkdownDialog from '@/components/custom/import-markdown-dialog';
+import PasteMarkdownDialog from '@/components/custom/paste-markdown-dialog';
 import TooltipButton from '@/components/custom/tooltip-button';
 import GithubIcon from '@/components/icons/github';
 import SidebarDirectoryPlaceholder from '@/components/layout/sidebar-directory-placeholder';
@@ -59,6 +63,8 @@ export default function Sidebar({ documents, folders, isAuthenticated, isDirecto
   const segment = useSelectedLayoutSegment();
   const { setTheme, theme } = useTheme();
   const [mounted, setMounted] = React.useState(false);
+  const [isImportMarkdownDialogOpen, setIsImportMarkdownDialogOpen] = React.useState(false);
+  const [isPasteMarkdownDialogOpen, setIsPasteMarkdownDialogOpen] = React.useState(false);
   const tooltipGroup = useTooltipGroup();
   const directoryTree = React.useMemo(() => {
     return buildDirectoryTree(folders, documents);
@@ -268,7 +274,7 @@ export default function Sidebar({ documents, folders, isAuthenticated, isDirecto
                         <ChevronDownIcon />
                       </Button>
                     </DropdownMenuTrigger>
-                    <DropdownMenuContent align="end">
+                    <DropdownMenuContent align="start">
                       <DropdownMenuItem
                         className="space-x-2"
                         onClick={() => {
@@ -277,6 +283,32 @@ export default function Sidebar({ documents, folders, isAuthenticated, isDirecto
                       >
                         <FolderPlusIcon />
                         New Folder
+                      </DropdownMenuItem>
+                      <DropdownMenuItem
+                        className="flex-col items-start gap-0.5 space-x-0"
+                        onClick={() => {
+                          setIsImportMarkdownDialogOpen(true);
+                        }}
+                      >
+                        <div className="flex items-center gap-2">
+                          <UploadIcon />
+                          Import Markdown
+                        </div>
+                        <p className="text-muted-foreground pl-6 text-xs">Select a .md file to create a new document</p>
+                      </DropdownMenuItem>
+                      <DropdownMenuItem
+                        className="flex-col items-start gap-0.5 space-x-0"
+                        onClick={() => {
+                          setIsPasteMarkdownDialogOpen(true);
+                        }}
+                      >
+                        <div className="flex items-center gap-2">
+                          <ClipboardPasteIcon />
+                          Paste Markdown
+                        </div>
+                        <p className="text-muted-foreground pl-6 text-xs">
+                          Paste markdown text to create a new document
+                        </p>
                       </DropdownMenuItem>
                     </DropdownMenuContent>
                   </DropdownMenu>
@@ -350,6 +382,9 @@ export default function Sidebar({ documents, folders, isAuthenticated, isDirecto
           </Show>
         </div>
       </aside>
+
+      <ImportMarkdownDialog open={isImportMarkdownDialogOpen} onOpenChange={setIsImportMarkdownDialogOpen} />
+      <PasteMarkdownDialog open={isPasteMarkdownDialogOpen} onOpenChange={setIsPasteMarkdownDialogOpen} />
     </>
   );
 }

--- a/src/lib/utils/convert-markdown-to-editor-state.ts
+++ b/src/lib/utils/convert-markdown-to-editor-state.ts
@@ -1,0 +1,22 @@
+import { buildEditorFromExtensions } from '@lexical/extension';
+import { $convertFromMarkdownString } from '@lexical/markdown';
+
+import LEXICAL_EDITOR_EXTENSION from '@/lib/constants/editor-extension';
+import ENHANCED_LEXICAL_TRANSFORMERS from '@/lib/constants/enhanced-lexical-transformers';
+
+export default function convertMarkdownToEditorState(markdown: string) {
+  const editor = buildEditorFromExtensions(LEXICAL_EDITOR_EXTENSION);
+
+  editor.update(
+    () => {
+      $convertFromMarkdownString(markdown, ENHANCED_LEXICAL_TRANSFORMERS, undefined, true);
+    },
+    { discrete: true }
+  );
+
+  const serialized = JSON.stringify(editor.getEditorState());
+
+  editor.dispose();
+
+  return serialized;
+}


### PR DESCRIPTION
## Description

Replaces the toolbar's import markdown button with an Export dropdown (download, copy as markdown, copy as plain text). Adds Import Markdown and Paste Markdown dialogs accessible from the sidebar root and folder context menus. Introduces a `convertMarkdownToEditorState` utility that builds a headless Lexical editor to serialize markdown into editor state.

## Type of Change

- [ ] Bug fix
- [x] New feature
- [ ] Documentation update
- [ ] Refactoring
- [ ] Performance improvement
- [ ] Test addition or update
- [ ] Build process or tooling change
- [ ] Code style or formatting change
- [ ] Other (please describe)

[//]: # 'Uncomment the following lines if your change is related to an issue'
[//]: # '## Related Issues (if any)'
[//]: #
[//]: # 'Fixes #(issue number)'

## Checklist

- [x] My code follows the project's style guidelines
- [x] I've tested my changes locally
- [ ] I've updated documentation if needed


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added Markdown import and paste options for creating new documents from files or clipboard text.
  * Added export actions to download, copy as Markdown, or copy as plain text from the editor.
  * Added folder-level Markdown import and paste actions in the sidebar.

* **Bug Fixes**
  * Improved dialog behavior by clearing selected content when closed and showing clearer success/error feedback during import.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->