### PR TITLE
feat(editor): add image upload, resizing and insertion support

### DIFF
--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -26,7 +26,11 @@
       "Bash(gh pr *)",
       "Bash(npm install *)",
       "mcp__chrome-devtools__hover",
-      "mcp__chrome-devtools__press_key"
+      "mcp__chrome-devtools__press_key",
+      "Bash(npx shadcn@latest add *)",
+      "Skill(clerk-webhooks)",
+      "Skill(clerk-webhooks:*)",
+      "mcp__chrome-devtools__fill"
     ],
     "deny": [],
     "ask": []

--- a/.env.example
+++ b/.env.example
@@ -5,10 +5,16 @@ ENCRYPTION_SECRET=0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcd
 NEXT_PUBLIC_SUPABASE_URL=http://127.0.0.1:54321
 NEXT_PUBLIC_SUPABASE_PUBLISHABLE_KEY=supabase_publishable_key
 
+# Supabase secret key for admin operations, e.g. storage cleanup on account deletion (required)
+SUPABASE_SECRET_KEY=supabase_secret_key
+
 # Clerk auth configuration (required)
 CLERK_SECRET_KEY=clerk_secret_key
 CLERK_DOMAIN=clerk_domain
 NEXT_PUBLIC_CLERK_PUBLISHABLE_KEY=clerk_publishable_key
+
+# Clerk webhook signing secret for verifying webhook payloads (required for account deletion cleanup)
+CLERK_WEBHOOK_SIGNING_SECRET=clerk_webhook_signing_secret
 
 # Sentry error tracking configuration (optional)
 SENTRY_DSN=sentry_dsn_url

--- a/src/app/api/webhooks/clerk/route.ts
+++ b/src/app/api/webhooks/clerk/route.ts
@@ -1,0 +1,46 @@
+import { verifyWebhook } from '@clerk/nextjs/webhooks';
+import * as Sentry from '@sentry/nextjs';
+import type { NextRequest } from 'next/server';
+
+import createSupabaseAdminClient from '@/lib/utils/create-supabase-admin-client';
+import removeStoragePrefix from '@/lib/utils/remove-storage-prefix';
+
+export async function POST(request: NextRequest) {
+  let event;
+
+  try {
+    event = await verifyWebhook(request);
+  } catch (error) {
+    Sentry.captureException(error);
+    console.error('Clerk webhook verification failed: ', error);
+
+    return new Response('Verification failed', { status: 400 });
+  }
+
+  if (event.type === 'user.deleted' && event.data.id) {
+    const userId = event.data.id;
+    const client = createSupabaseAdminClient();
+
+    await removeStoragePrefix(client, userId);
+
+    const { error: documentsError } = await client.from('documents').delete().eq('user_id', userId);
+
+    if (documentsError) {
+      Sentry.captureException(documentsError);
+      console.error('Error removing documents of deleted user: ', documentsError);
+
+      return new Response('Failed to remove user documents', { status: 500 });
+    }
+
+    const { error: foldersError } = await client.from('folders').delete().eq('user_id', userId);
+
+    if (foldersError) {
+      Sentry.captureException(foldersError);
+      console.error('Error removing folders of deleted user: ', foldersError);
+
+      return new Response('Failed to remove user folders', { status: 500 });
+    }
+  }
+
+  return new Response('OK', { status: 200 });
+}

--- a/src/components/custom/insert-image-dialog.tsx
+++ b/src/components/custom/insert-image-dialog.tsx
@@ -1,0 +1,288 @@
+'use client';
+
+import { useUser } from '@clerk/nextjs';
+import { useLexicalComposerContext } from '@lexical/react/LexicalComposerContext';
+import * as Sentry from '@sentry/nextjs';
+import { ImageIcon, UploadIcon, LoaderCircleIcon } from 'lucide-react';
+import Link from 'next/link';
+import posthog from 'posthog-js';
+import * as React from 'react';
+import { toast } from 'sonner';
+
+import { useDocument } from '@/components/providers/document-provider';
+import { Button } from '@/components/ui/button';
+import { Dialog, DialogClose, DialogTitle, DialogFooter, DialogHeader, DialogContent } from '@/components/ui/dialog';
+import { Input } from '@/components/ui/input';
+import { Label } from '@/components/ui/label';
+import { Tabs, TabsList, TabsContent, TabsTrigger } from '@/components/ui/tabs';
+import INSERT_IMAGE_COMMAND from '@/lib/constants/editor-insert-image-command';
+import useClerkSupabaseClient from '@/lib/hooks/use-clerk-supabase-client';
+import getErrorMessage from '@/lib/utils/get-error-message';
+
+const MAX_FILE_SIZE = 10 * 1024 * 1024;
+
+const ALLOWED_IMAGE_TYPES: Record<string, string> = {
+  'image/gif': 'gif',
+  'image/jpeg': 'jpg',
+  'image/png': 'png',
+  'image/webp': 'webp',
+};
+
+function isValidImageUrl(url: string) {
+  try {
+    const parsedUrl = new URL(url);
+
+    return parsedUrl.protocol === 'http:' || parsedUrl.protocol === 'https:';
+  } catch {
+    return false;
+  }
+}
+
+type InsertImageDialogProps = {
+  open: boolean;
+  onOpenChange: (open: boolean) => void;
+};
+
+export default function InsertImageDialog({ onOpenChange, open }: InsertImageDialogProps) {
+  const [editor] = useLexicalComposerContext();
+  const { isSignedIn, user } = useUser();
+  const { activeDocument } = useDocument();
+  const supabase = useClerkSupabaseClient();
+  const [url, setUrl] = React.useState('');
+  const [altText, setAltText] = React.useState('');
+  const [file, setFile] = React.useState<File | null>(null);
+  const [isUploading, setIsUploading] = React.useState(false);
+  const fileInputRef = React.useRef<HTMLInputElement>(null);
+
+  function resetState() {
+    setUrl('');
+    setAltText('');
+    setFile(null);
+    setIsUploading(false);
+
+    if (fileInputRef.current) {
+      fileInputRef.current.value = '';
+    }
+  }
+
+  function handleOpenChange(nextOpen: boolean) {
+    if (!nextOpen) {
+      resetState();
+    }
+
+    onOpenChange(nextOpen);
+  }
+
+  function handleFileChange(event: React.ChangeEvent<HTMLInputElement>) {
+    const selectedFile = event.target.files?.[0] ?? null;
+
+    if (!selectedFile) {
+      setFile(null);
+
+      return;
+    }
+
+    if (!ALLOWED_IMAGE_TYPES[selectedFile.type]) {
+      toast.error('Unsupported file type', {
+        description: 'Please choose a PNG, JPEG, GIF or WebP image',
+      });
+
+      return;
+    }
+
+    if (selectedFile.size > MAX_FILE_SIZE) {
+      toast.error('File is too large', {
+        description: 'The maximum allowed image size is 10 MB',
+      });
+
+      return;
+    }
+
+    setFile(selectedFile);
+  }
+
+  function handleUrlInsert() {
+    if (!isValidImageUrl(url)) {
+      toast.error('Invalid image URL', {
+        description: 'Please enter a valid http(s) URL',
+      });
+
+      return;
+    }
+
+    editor.dispatchCommand(INSERT_IMAGE_COMMAND, { altText, src: url });
+    posthog.capture('image_inserted_by_url');
+    handleOpenChange(false);
+  }
+
+  async function handleUpload() {
+    if (!file || !user || !activeDocument) {
+      return;
+    }
+
+    try {
+      setIsUploading(true);
+
+      const extension = ALLOWED_IMAGE_TYPES[file.type];
+      const path = `${user.id}/${activeDocument.id}/${crypto.randomUUID()}.${extension}`;
+
+      const { error } = await supabase.storage.from('images').upload(path, file, {
+        contentType: file.type,
+      });
+
+      if (error) {
+        throw error;
+      }
+
+      const {
+        data: { publicUrl },
+      } = supabase.storage.from('images').getPublicUrl(path);
+
+      editor.dispatchCommand(INSERT_IMAGE_COMMAND, {
+        altText: altText || file.name,
+        src: publicUrl,
+      });
+
+      posthog.capture('image_uploaded', { documentId: activeDocument.id });
+      handleOpenChange(false);
+    } catch (error) {
+      Sentry.captureException(error);
+      console.error('Error uploading image: ', error);
+      toast.error('Error uploading image', {
+        description: getErrorMessage(error),
+      });
+    } finally {
+      setIsUploading(false);
+    }
+  }
+
+  return (
+    <Dialog open={open} onOpenChange={handleOpenChange}>
+      {open && (
+        <DialogContent className="sm:max-w-[425px]">
+          <DialogHeader>
+            <DialogTitle>Insert Image</DialogTitle>
+          </DialogHeader>
+
+          <Tabs defaultValue="url">
+            <TabsList className="w-full">
+              <TabsTrigger value="url">Paste URL</TabsTrigger>
+              <TabsTrigger value="upload">Upload</TabsTrigger>
+            </TabsList>
+
+            <TabsContent value="url" className="space-y-4 pt-2">
+              <div className="space-y-2">
+                <Label htmlFor="image-url">Image URL</Label>
+                <Input
+                  value={url}
+                  id="image-url"
+                  placeholder="https://example.com/image.png"
+                  onChange={(event) => {
+                    setUrl(event.target.value);
+                  }}
+                />
+              </div>
+              <div className="space-y-2">
+                <Label htmlFor="image-url-alt">Alt text (optional)</Label>
+                <Input
+                  value={altText}
+                  id="image-url-alt"
+                  placeholder="Descriptive alternative text"
+                  onChange={(event) => {
+                    setAltText(event.target.value);
+                  }}
+                />
+              </div>
+              <DialogFooter>
+                <DialogClose asChild>
+                  <Button variant="outline">Cancel</Button>
+                </DialogClose>
+                <Button disabled={!url} onClick={handleUrlInsert}>
+                  Insert
+                </Button>
+              </DialogFooter>
+            </TabsContent>
+
+            <TabsContent value="upload" className="space-y-4 pt-2">
+              {!isSignedIn ? (
+                <div className="space-y-4 py-4 text-center">
+                  <ImageIcon className="text-muted-foreground mx-auto size-8" />
+                  <p className="text-muted-foreground text-sm">
+                    Uploading images is available to registered users. Log in to upload images directly to your
+                    documents.
+                  </p>
+                  <Button asChild>
+                    <Link href="/login">Log in</Link>
+                  </Button>
+                </div>
+              ) : !activeDocument ? (
+                <div className="space-y-4 py-4 text-center">
+                  <ImageIcon className="text-muted-foreground mx-auto size-8" />
+                  <p className="text-muted-foreground text-sm">
+                    Save the document first to upload images. Uploaded images are stored alongside the document.
+                  </p>
+                </div>
+              ) : (
+                <>
+                  <input
+                    type="file"
+                    className="hidden"
+                    ref={fileInputRef}
+                    onChange={handleFileChange}
+                    accept="image/png,image/jpeg,image/gif,image/webp"
+                  />
+                  <button
+                    type="button"
+                    onClick={() => {
+                      fileInputRef.current?.click();
+                    }}
+                    className="border-input hover:bg-accent hover:text-accent-foreground flex w-full flex-col items-center justify-center gap-2 rounded-md border border-dashed px-6 py-10 text-center transition-colors"
+                  >
+                    {file ? (
+                      <>
+                        <ImageIcon className="text-muted-foreground size-6" />
+                        <span className="text-sm font-medium">{file.name}</span>
+                        <span className="text-muted-foreground text-xs">Click to choose a different image</span>
+                      </>
+                    ) : (
+                      <>
+                        <UploadIcon className="text-muted-foreground size-6" />
+                        <span className="text-sm font-medium">Select an image</span>
+                        <span className="text-muted-foreground text-xs">PNG, JPEG, GIF or WebP, up to 10 MB</span>
+                      </>
+                    )}
+                  </button>
+                  <div className="space-y-2">
+                    <Label htmlFor="image-upload-alt">Alt text (optional)</Label>
+                    <Input
+                      value={altText}
+                      id="image-upload-alt"
+                      placeholder="Descriptive alternative text"
+                      onChange={(event) => {
+                        setAltText(event.target.value);
+                      }}
+                    />
+                  </div>
+                  <DialogFooter>
+                    <DialogClose asChild>
+                      <Button variant="outline">Cancel</Button>
+                    </DialogClose>
+                    <Button
+                      disabled={!file || isUploading}
+                      onClick={() => {
+                        void handleUpload();
+                      }}
+                    >
+                      {isUploading && <LoaderCircleIcon className="mr-2 animate-spin" />}
+                      Upload
+                    </Button>
+                  </DialogFooter>
+                </>
+              )}
+            </TabsContent>
+          </Tabs>
+        </DialogContent>
+      )}
+    </Dialog>
+  );
+}

--- a/src/components/editor/editor.tsx
+++ b/src/components/editor/editor.tsx
@@ -18,6 +18,7 @@ import posthog from 'posthog-js';
 import * as React from 'react';
 
 import FloatingLinkEditorPlugin from '@/components/editor/plugins/floating-link-editor-plugin';
+import ImagesPlugin from '@/components/editor/plugins/images-plugin';
 import ShortcutsPlugin from '@/components/editor/plugins/shortcuts-plugin';
 import TableActionMenuPlugin from '@/components/editor/plugins/table-action-menu-plugin';
 import TableCellResizerPlugin from '@/components/editor/plugins/table-cell-resizer-plugin';
@@ -138,6 +139,7 @@ export default function Editor() {
         }
       />
       <ListPlugin />
+      <ImagesPlugin />
       <HistoryPlugin />
       <ShortcutsPlugin />
       <CheckListPlugin />

--- a/src/components/editor/nodes/image-component.tsx
+++ b/src/components/editor/nodes/image-component.tsx
@@ -1,9 +1,28 @@
-import { useState } from 'react';
+import { useLexicalComposerContext } from '@lexical/react/LexicalComposerContext';
+import { useLexicalEditable } from '@lexical/react/useLexicalEditable';
+import { useLexicalNodeSelection } from '@lexical/react/useLexicalNodeSelection';
+import type { NodeKey } from 'lexical';
+import {
+  $getNodeByKey,
+  $getSelection,
+  CLICK_COMMAND,
+  mergeRegister,
+  $isNodeSelection,
+  DRAGSTART_COMMAND,
+  COMMAND_PRIORITY_LOW,
+} from 'lexical';
+import * as React from 'react';
+
+import { $isImageNode } from '@/components/editor/nodes/image-node';
+import ImageResizer from '@/components/editor/nodes/image-resizer';
+import cn from '@/lib/utils/cn';
 
 type ImageComponentProps = {
   altText: string;
   height: 'inherit' | number;
   maxWidth: number;
+  nodeKey: NodeKey;
+  resizable: boolean;
   src: string;
   width: 'inherit' | number;
 };
@@ -31,8 +50,13 @@ function BrokenImage() {
   );
 }
 
-function LazyImage({ altText, height, maxWidth, src, width }: ImageComponentProps) {
-  const [hasError, setHasError] = useState(false);
+type LazyImageProps = Omit<ImageComponentProps, 'nodeKey' | 'resizable'> & {
+  imageRef: { current: HTMLImageElement | null };
+  isFocused: boolean;
+};
+
+function LazyImage({ altText, height, imageRef, isFocused, maxWidth, src, width }: LazyImageProps) {
+  const [hasError, setHasError] = React.useState(false);
 
   if (hasError) {
     return <BrokenImage />;
@@ -42,25 +66,123 @@ function LazyImage({ altText, height, maxWidth, src, width }: ImageComponentProp
     <img
       src={src}
       alt={altText}
+      ref={imageRef}
       loading="lazy"
       draggable={false}
-      className="h-auto max-w-full rounded-lg"
       onError={() => {
         return setHasError(true);
       }}
+      className={cn('h-auto max-w-full rounded-lg', isFocused && 'ring-primary ring-2')}
       style={{
         height: height === 'inherit' ? 'auto' : `${height}px`,
-        maxWidth: `${maxWidth}px`,
+        maxWidth: width === 'inherit' ? `${maxWidth}px` : undefined,
         width: width === 'inherit' ? '100%' : `${width}px`,
       }}
     />
   );
 }
 
-export default function ImageComponent(props: ImageComponentProps) {
+export default function ImageComponent({
+  altText,
+  height,
+  maxWidth,
+  nodeKey,
+  resizable,
+  src,
+  width,
+}: ImageComponentProps) {
+  const imageRef = React.useRef<HTMLImageElement | null>(null);
+  const [isSelected, setSelected, clearSelection] = useLexicalNodeSelection(nodeKey);
+  const [isResizing, setIsResizing] = React.useState(false);
+  const [editor] = useLexicalComposerContext();
+  const isEditable = useLexicalEditable();
+
+  const isInNodeSelection = React.useMemo(() => {
+    return (
+      isSelected &&
+      editor.read(() => {
+        const selection = $getSelection();
+
+        return $isNodeSelection(selection) && selection.has(nodeKey);
+      })
+    );
+  }, [editor, isSelected, nodeKey]);
+
+  const onClick = React.useCallback(
+    (event: MouseEvent) => {
+      if (isResizing) {
+        return true;
+      }
+
+      if (event.target === imageRef.current) {
+        if (event.shiftKey) {
+          setSelected(!isSelected);
+        } else {
+          clearSelection();
+          setSelected(true);
+        }
+
+        return true;
+      }
+
+      return false;
+    },
+    [isResizing, isSelected, setSelected, clearSelection]
+  );
+
+  React.useEffect(() => {
+    return mergeRegister(
+      editor.registerCommand(CLICK_COMMAND, onClick, COMMAND_PRIORITY_LOW),
+      editor.registerCommand(
+        DRAGSTART_COMMAND,
+        (event) => {
+          if (event.target === imageRef.current) {
+            event.preventDefault();
+
+            return true;
+          }
+
+          return false;
+        },
+        COMMAND_PRIORITY_LOW
+      )
+    );
+  }, [editor, onClick]);
+
+  function onResizeStart() {
+    setIsResizing(true);
+  }
+
+  function onResizeEnd(nextWidth: 'inherit' | number, nextHeight: 'inherit' | number) {
+    setTimeout(() => {
+      setIsResizing(false);
+    }, 200);
+
+    editor.update(() => {
+      const node = $getNodeByKey(nodeKey);
+
+      if ($isImageNode(node)) {
+        node.setWidthAndHeight(nextWidth, nextHeight);
+      }
+    });
+  }
+
+  const isFocused = (isSelected || isResizing) && isEditable;
+
   return (
-    <div className="relative my-4">
-      <LazyImage {...props} />
-    </div>
+    <>
+      <LazyImage
+        src={src}
+        width={width}
+        height={height}
+        altText={altText}
+        imageRef={imageRef}
+        maxWidth={maxWidth}
+        isFocused={isFocused}
+      />
+      {resizable && isInNodeSelection && isFocused && (
+        <ImageResizer editor={editor} imageRef={imageRef} onResizeEnd={onResizeEnd} onResizeStart={onResizeStart} />
+      )}
+    </>
   );
 }

--- a/src/components/editor/nodes/image-node.tsx
+++ b/src/components/editor/nodes/image-node.tsx
@@ -13,7 +13,7 @@ import type { JSX } from 'react';
 
 import ImageComponent from './image-component';
 
-type ImagePayload = {
+export type ImagePayload = {
   altText: string;
   height?: 'inherit' | number;
   key?: NodeKey;
@@ -115,6 +115,12 @@ export class ImageNode extends DecoratorNode<JSX.Element> {
     return this.__altText;
   }
 
+  setWidthAndHeight(width: 'inherit' | number, height: 'inherit' | number): void {
+    const writable = this.getWritable();
+    writable.__width = width;
+    writable.__height = height;
+  }
+
   createDOM(config: EditorConfig): HTMLElement {
     const span = document.createElement('span');
     const theme = config.theme;
@@ -134,9 +140,11 @@ export class ImageNode extends DecoratorNode<JSX.Element> {
   decorate(): JSX.Element {
     return (
       <ImageComponent
+        resizable
         src={this.__src}
         width={this.__width}
         height={this.__height}
+        nodeKey={this.getKey()}
         altText={this.__altText}
         maxWidth={this.__maxWidth}
       />

--- a/src/components/editor/nodes/image-resizer.tsx
+++ b/src/components/editor/nodes/image-resizer.tsx
@@ -1,0 +1,235 @@
+import { calculateZoomLevel } from '@lexical/utils';
+import type { LexicalEditor } from 'lexical';
+import * as React from 'react';
+
+const Direction = {
+  east: 1 << 0,
+  north: 1 << 3,
+  south: 1 << 1,
+  west: 1 << 2,
+};
+
+const RESIZER_HANDLES = [
+  {
+    className: 'top-[-6px] left-1/2 -translate-x-1/2 cursor-n-resize',
+    direction: Direction.north,
+  },
+  {
+    className: 'top-[-6px] right-[-6px] cursor-ne-resize',
+    direction: Direction.north | Direction.east,
+  },
+  {
+    className: 'top-1/2 right-[-6px] -translate-y-1/2 cursor-e-resize',
+    direction: Direction.east,
+  },
+  {
+    className: 'right-[-6px] bottom-[-6px] cursor-se-resize',
+    direction: Direction.south | Direction.east,
+  },
+  {
+    className: 'bottom-[-6px] left-1/2 -translate-x-1/2 cursor-s-resize',
+    direction: Direction.south,
+  },
+  {
+    className: 'bottom-[-6px] left-[-6px] cursor-sw-resize',
+    direction: Direction.south | Direction.west,
+  },
+  {
+    className: 'top-1/2 left-[-6px] -translate-y-1/2 cursor-w-resize',
+    direction: Direction.west,
+  },
+  {
+    className: 'top-[-6px] left-[-6px] cursor-nw-resize',
+    direction: Direction.north | Direction.west,
+  },
+];
+
+function clamp(value: number, min: number, max: number) {
+  return Math.min(Math.max(value, min), max);
+}
+
+type ImageResizerProps = {
+  editor: LexicalEditor;
+  imageRef: { current: HTMLImageElement | null };
+  onResizeEnd: (width: 'inherit' | number, height: 'inherit' | number) => void;
+  onResizeStart: () => void;
+};
+
+export default function ImageResizer({ editor, imageRef, onResizeEnd, onResizeStart }: ImageResizerProps) {
+  const userSelect = React.useRef({ priority: '', value: 'default' });
+
+  const positioningRef = React.useRef({
+    currentHeight: 0 as 'inherit' | number,
+    currentWidth: 0 as 'inherit' | number,
+    direction: 0,
+    isResizing: false,
+    ratio: 0,
+    startHeight: 0,
+    startWidth: 0,
+    startX: 0,
+    startY: 0,
+  });
+
+  const editorRootElement = editor.getRootElement();
+
+  const maxWidthContainer = React.useMemo(() => {
+    if (editorRootElement === null) {
+      return 100;
+    }
+
+    const { paddingLeft, paddingRight } = getComputedStyle(editorRootElement);
+
+    return editorRootElement.clientWidth - parseFloat(paddingLeft) - parseFloat(paddingRight);
+  }, [editorRootElement]);
+
+  const maxHeightContainer = editorRootElement !== null ? editorRootElement.getBoundingClientRect().height - 20 : 100;
+
+  const minWidth = 100;
+  const minHeight = 100;
+
+  function setStartCursor(direction: number) {
+    const ew = direction === Direction.east || direction === Direction.west;
+    const ns = direction === Direction.north || direction === Direction.south;
+
+    const nwse =
+      (direction & Direction.north && direction & Direction.west) ||
+      (direction & Direction.south && direction & Direction.east);
+
+    const cursorDir = ew ? 'ew' : ns ? 'ns' : nwse ? 'nwse' : 'nesw';
+
+    if (editorRootElement !== null) {
+      editorRootElement.style.setProperty('cursor', `${cursorDir}-resize`, 'important');
+    }
+
+    document.body.style.setProperty('cursor', `${cursorDir}-resize`, 'important');
+    userSelect.current.value = document.body.style.getPropertyValue('-webkit-user-select');
+    userSelect.current.priority = document.body.style.getPropertyPriority('-webkit-user-select');
+    document.body.style.setProperty('-webkit-user-select', 'none', 'important');
+  }
+
+  function setEndCursor() {
+    if (editorRootElement !== null) {
+      editorRootElement.style.setProperty('cursor', 'text');
+    }
+
+    document.body.style.setProperty('cursor', 'default');
+    document.body.style.setProperty('-webkit-user-select', userSelect.current.value, userSelect.current.priority);
+  }
+
+  function handlePointerDown(event: React.PointerEvent<HTMLDivElement>, direction: number) {
+    if (!editor.isEditable()) {
+      return;
+    }
+
+    const image = imageRef.current;
+
+    if (image !== null) {
+      event.preventDefault();
+      const { height, width } = image.getBoundingClientRect();
+      const zoom = calculateZoomLevel(image);
+      const positioning = positioningRef.current;
+      positioning.startWidth = width;
+      positioning.startHeight = height;
+      positioning.ratio = width / height;
+      positioning.currentWidth = width;
+      positioning.currentHeight = height;
+      positioning.startX = event.clientX / zoom;
+      positioning.startY = event.clientY / zoom;
+      positioning.isResizing = true;
+      positioning.direction = direction;
+
+      setStartCursor(direction);
+      onResizeStart();
+
+      image.style.maxWidth = 'none';
+      image.style.height = `${height}px`;
+      image.style.width = `${width}px`;
+
+      document.addEventListener('pointermove', handlePointerMove);
+      document.addEventListener('pointerup', handlePointerUp);
+    }
+  }
+
+  function handlePointerMove(event: PointerEvent) {
+    const image = imageRef.current;
+    const positioning = positioningRef.current;
+
+    const isHorizontal = positioning.direction & (Direction.east | Direction.west);
+    const isVertical = positioning.direction & (Direction.south | Direction.north);
+
+    if (image !== null && positioning.isResizing) {
+      const zoom = calculateZoomLevel(image);
+
+      if (isHorizontal && isVertical) {
+        let diff = Math.floor(positioning.startX - event.clientX / zoom);
+        diff = positioning.direction & Direction.east ? -diff : diff;
+
+        const width = clamp(positioning.startWidth + diff, minWidth, maxWidthContainer);
+
+        const height = width / positioning.ratio;
+        image.style.width = `${width}px`;
+        image.style.height = `${height}px`;
+        positioning.currentHeight = height;
+        positioning.currentWidth = width;
+      } else if (isVertical) {
+        let diff = Math.floor(positioning.startY - event.clientY / zoom);
+        diff = positioning.direction & Direction.south ? -diff : diff;
+
+        const height = clamp(positioning.startHeight + diff, minHeight, maxHeightContainer);
+
+        image.style.height = `${height}px`;
+        positioning.currentHeight = height;
+      } else {
+        let diff = Math.floor(positioning.startX - event.clientX / zoom);
+        diff = positioning.direction & Direction.east ? -diff : diff;
+
+        const width = clamp(positioning.startWidth + diff, minWidth, maxWidthContainer);
+
+        image.style.width = `${width}px`;
+        positioning.currentWidth = width;
+      }
+    }
+  }
+
+  function handlePointerUp() {
+    const image = imageRef.current;
+    const positioning = positioningRef.current;
+
+    if (image !== null && positioning.isResizing) {
+      const width = positioning.currentWidth;
+      const height = positioning.currentHeight;
+      positioning.startWidth = 0;
+      positioning.startHeight = 0;
+      positioning.ratio = 0;
+      positioning.startX = 0;
+      positioning.startY = 0;
+      positioning.currentWidth = 0;
+      positioning.currentHeight = 0;
+      positioning.isResizing = false;
+
+      image.style.maxWidth = '';
+
+      setEndCursor();
+      onResizeEnd(width, height);
+
+      document.removeEventListener('pointermove', handlePointerMove);
+      document.removeEventListener('pointerup', handlePointerUp);
+    }
+  }
+
+  return (
+    <>
+      {RESIZER_HANDLES.map(({ className, direction }) => {
+        return (
+          <div
+            key={direction}
+            className={`bg-primary border-background absolute size-2 touch-none border ${className}`}
+            onPointerDown={(event) => {
+              handlePointerDown(event, direction);
+            }}
+          />
+        );
+      })}
+    </>
+  );
+}

--- a/src/components/editor/plugins/images-plugin.tsx
+++ b/src/components/editor/plugins/images-plugin.tsx
@@ -1,0 +1,30 @@
+import { useLexicalComposerContext } from '@lexical/react/LexicalComposerContext';
+import { $wrapNodeInElement } from '@lexical/utils';
+import { $insertNodes, $isRootOrShadowRoot, $createParagraphNode, COMMAND_PRIORITY_EDITOR } from 'lexical';
+import * as React from 'react';
+
+import { $createImageNode } from '@/components/editor/nodes/image-node';
+import INSERT_IMAGE_COMMAND from '@/lib/constants/editor-insert-image-command';
+
+export default function ImagesPlugin() {
+  const [editor] = useLexicalComposerContext();
+
+  React.useEffect(() => {
+    return editor.registerCommand(
+      INSERT_IMAGE_COMMAND,
+      (payload) => {
+        const imageNode = $createImageNode(payload);
+        $insertNodes([imageNode]);
+
+        if ($isRootOrShadowRoot(imageNode.getParentOrThrow())) {
+          $wrapNodeInElement(imageNode, $createParagraphNode).selectEnd();
+        }
+
+        return true;
+      },
+      COMMAND_PRIORITY_EDITOR
+    );
+  }, [editor]);
+
+  return null;
+}

--- a/src/components/editor/plugins/toolbar-editor-plugin.tsx
+++ b/src/components/editor/plugins/toolbar-editor-plugin.tsx
@@ -34,6 +34,7 @@ import {
   CopyIcon,
   QuoteIcon,
   TableIcon,
+  ImageIcon,
   IndentIcon,
   ItalicIcon,
   EraserIcon,
@@ -60,6 +61,7 @@ import { toast } from 'sonner';
 
 import EditorColorPicker from '@/components/custom/editor-color-picker';
 import FontSizeInput from '@/components/custom/font-size-input';
+import InsertImageDialog from '@/components/custom/insert-image-dialog';
 import Shortcut from '@/components/custom/shortcut';
 import TableSizePicker from '@/components/custom/table-size-picker';
 import TooltipButton from '@/components/custom/tooltip-button';
@@ -138,6 +140,7 @@ export default function ToolbarEditorPlugin() {
   const [isTextFormatDropdownOpen, setIsTextFormatDropdownOpen] = React.useState(false);
   const [isExportDropdownOpen, setIsExportDropdownOpen] = React.useState(false);
   const [isTableSizePickerOpen, setIsTableSizePickerOpen] = React.useState(false);
+  const [isInsertImageDialogOpen, setIsInsertImageDialogOpen] = React.useState(false);
   const [isCellBackgroundColorPickerOpen, setIsCellBackgroundColorPickerOpen] = React.useState(false);
   const [fontColor, setFontColor] = React.useState('');
   const [backgroundColor, setBackgroundColor] = React.useState('');
@@ -713,6 +716,19 @@ export default function ToolbarEditorPlugin() {
             />
           </PopoverContent>
         </Popover>
+
+        <TooltipButton
+          {...tooltipGroup.getTooltipProps()}
+          variant="ghost"
+          tooltip="Insert image"
+          onClick={() => {
+            setIsInsertImageDialogOpen(true);
+          }}
+        >
+          <ImageIcon />
+        </TooltipButton>
+
+        <InsertImageDialog open={isInsertImageDialogOpen} onOpenChange={setIsInsertImageDialogOpen} />
 
         <Separator className="h-6!" orientation="vertical" />
 

--- a/src/components/providers/document-provider.tsx
+++ b/src/components/providers/document-provider.tsx
@@ -610,7 +610,7 @@ export default function DocumentProvider({ children, documents, folders, isAuthe
           closeActiveDocument();
         }
 
-        await removeFolder(folderId);
+        await removeFolder(folderId, [...removedFolderIds]);
         posthog.capture('folder_removed', { folderId });
         toast.success('Folder removed successfully');
 

--- a/src/components/ui/tabs.tsx
+++ b/src/components/ui/tabs.tsx
@@ -1,0 +1,71 @@
+'use client';
+
+import { cva, type VariantProps } from 'class-variance-authority';
+import { Tabs as TabsPrimitive } from 'radix-ui';
+import * as React from 'react';
+
+import cn from '@/lib/utils/cn';
+
+function Tabs({ className, orientation = 'horizontal', ...props }: React.ComponentProps<typeof TabsPrimitive.Root>) {
+  return (
+    <TabsPrimitive.Root
+      data-slot="tabs"
+      orientation={orientation}
+      data-orientation={orientation}
+      className={cn('group/tabs flex gap-2 data-[orientation=horizontal]:flex-col', className)}
+      {...props}
+    />
+  );
+}
+
+const tabsListVariants = cva(
+  'group/tabs-list text-muted-foreground inline-flex w-fit items-center justify-center rounded-lg p-[3px] group-data-[orientation=horizontal]/tabs:h-9 group-data-[orientation=vertical]/tabs:h-fit group-data-[orientation=vertical]/tabs:flex-col data-[variant=line]:rounded-none',
+  {
+    defaultVariants: {
+      variant: 'default',
+    },
+    variants: {
+      variant: {
+        default: 'bg-muted',
+        line: 'gap-1 bg-transparent',
+      },
+    },
+  }
+);
+
+function TabsList({
+  className,
+  variant = 'default',
+  ...props
+}: React.ComponentProps<typeof TabsPrimitive.List> & VariantProps<typeof tabsListVariants>) {
+  return (
+    <TabsPrimitive.List
+      data-slot="tabs-list"
+      data-variant={variant}
+      className={cn(tabsListVariants({ variant }), className)}
+      {...props}
+    />
+  );
+}
+
+function TabsTrigger({ className, ...props }: React.ComponentProps<typeof TabsPrimitive.Trigger>) {
+  return (
+    <TabsPrimitive.Trigger
+      data-slot="tabs-trigger"
+      className={cn(
+        "text-foreground/60 hover:text-foreground focus-visible:border-ring focus-visible:ring-ring/50 focus-visible:outline-ring dark:text-muted-foreground dark:hover:text-foreground relative inline-flex h-[calc(100%-1px)] flex-1 items-center justify-center gap-1.5 rounded-md border border-transparent px-2 py-1 text-sm font-medium whitespace-nowrap transition-all group-data-[orientation=vertical]/tabs:w-full group-data-[orientation=vertical]/tabs:justify-start focus-visible:ring-[3px] focus-visible:outline-1 disabled:pointer-events-none disabled:opacity-50 group-data-[variant=default]/tabs-list:data-[state=active]:shadow-sm group-data-[variant=line]/tabs-list:data-[state=active]:shadow-none [&_svg]:pointer-events-none [&_svg]:shrink-0 [&_svg:not([class*='size-'])]:size-4",
+        'group-data-[variant=line]/tabs-list:bg-transparent group-data-[variant=line]/tabs-list:data-[state=active]:bg-transparent dark:group-data-[variant=line]/tabs-list:data-[state=active]:border-transparent dark:group-data-[variant=line]/tabs-list:data-[state=active]:bg-transparent',
+        'data-[state=active]:bg-background data-[state=active]:text-foreground dark:data-[state=active]:border-input dark:data-[state=active]:bg-input/30 dark:data-[state=active]:text-foreground',
+        'after:bg-foreground after:absolute after:opacity-0 after:transition-opacity group-data-[orientation=horizontal]/tabs:after:inset-x-0 group-data-[orientation=horizontal]/tabs:after:bottom-[-5px] group-data-[orientation=horizontal]/tabs:after:h-0.5 group-data-[orientation=vertical]/tabs:after:inset-y-0 group-data-[orientation=vertical]/tabs:after:-right-1 group-data-[orientation=vertical]/tabs:after:w-0.5 group-data-[variant=line]/tabs-list:data-[state=active]:after:opacity-100',
+        className
+      )}
+      {...props}
+    />
+  );
+}
+
+function TabsContent({ className, ...props }: React.ComponentProps<typeof TabsPrimitive.Content>) {
+  return <TabsPrimitive.Content data-slot="tabs-content" className={cn('flex-1 outline-none', className)} {...props} />;
+}
+
+export { Tabs, TabsList, TabsTrigger, TabsContent, tabsListVariants };

--- a/src/lib/actions/document.actions.ts
+++ b/src/lib/actions/document.actions.ts
@@ -1,11 +1,13 @@
 'use server';
 
+import { auth } from '@clerk/nextjs/server';
 import camelcaseKeys from 'camelcase-keys';
 import decamelizeKeys from 'decamelize-keys';
 import { revalidatePath } from 'next/cache';
 
 import type { DocumentsInsert, DocumentsUpdate } from '@/lib/models/document.model';
 import createClerkSupabaseClientSsr from '@/lib/utils/create-clerk-supabase-ssr-client';
+import removeStoragePrefix from '@/lib/utils/remove-storage-prefix';
 
 export async function createDocument(body: DocumentsInsert) {
   const client = await createClerkSupabaseClientSsr();
@@ -28,6 +30,12 @@ export async function removeDocument(documentId: string) {
 
   if (error) {
     throw error;
+  }
+
+  const { userId } = await auth();
+
+  if (userId) {
+    await removeStoragePrefix(client, `${userId}/${documentId}`);
   }
 
   revalidatePath('/');

--- a/src/lib/actions/folder.actions.ts
+++ b/src/lib/actions/folder.actions.ts
@@ -1,11 +1,13 @@
 'use server';
 
+import { auth } from '@clerk/nextjs/server';
 import camelcaseKeys from 'camelcase-keys';
 import decamelizeKeys from 'decamelize-keys';
 import { revalidatePath } from 'next/cache';
 
 import type { FoldersInsert, FoldersUpdate } from '@/lib/models/folder.model';
 import createClerkSupabaseClientSsr from '@/lib/utils/create-clerk-supabase-ssr-client';
+import removeStoragePrefix from '@/lib/utils/remove-storage-prefix';
 
 export async function createFolder(body: FoldersInsert) {
   const client = await createClerkSupabaseClientSsr();
@@ -21,13 +23,30 @@ export async function createFolder(body: FoldersInsert) {
   return camelcaseKeys(data[0]);
 }
 
-export async function removeFolder(folderId: string) {
+export async function removeFolder(folderId: string, subtreeFolderIds: string[]) {
   const client = await createClerkSupabaseClientSsr();
+
+  const { data: documents, error: documentsError } = await client
+    .from('documents')
+    .select('id')
+    .in('folder_id', subtreeFolderIds);
+
+  if (documentsError) {
+    throw documentsError;
+  }
 
   const { error } = await client.from('folders').delete().eq('id', folderId);
 
   if (error) {
     throw error;
+  }
+
+  const { userId } = await auth();
+
+  if (userId) {
+    for (const document of documents) {
+      await removeStoragePrefix(client, `${userId}/${document.id}`);
+    }
   }
 
   revalidatePath('/');

--- a/src/lib/constants/editor-extension.ts
+++ b/src/lib/constants/editor-extension.ts
@@ -50,7 +50,7 @@ const LEXICAL_EDITOR_EXTENSION = defineExtension({
   },
   theme: {
     hr: 'border-t border-slate-200 my-4',
-    image: 'my-4',
+    image: 'relative my-4 inline-block max-w-full select-none',
     link: 'text-sky-500 underline hover:text-blue-600',
     paragraph: 'my-1 text-base leading-5',
     quote: 'italic text-slate-500 border-l-4 border-slate-500 pl-2',

--- a/src/lib/constants/editor-insert-image-command.ts
+++ b/src/lib/constants/editor-insert-image-command.ts
@@ -1,0 +1,7 @@
+import { createCommand } from 'lexical';
+
+import type { ImagePayload } from '@/components/editor/nodes/image-node';
+
+const INSERT_IMAGE_COMMAND = createCommand<ImagePayload>('INSERT_IMAGE_COMMAND');
+
+export default INSERT_IMAGE_COMMAND;

--- a/src/lib/hooks/use-clerk-supabase-client.ts
+++ b/src/lib/hooks/use-clerk-supabase-client.ts
@@ -1,0 +1,24 @@
+import { useSession } from '@clerk/nextjs';
+import { createClient } from '@supabase/supabase-js';
+import * as React from 'react';
+
+import type { Database } from '@db-types';
+
+const supabaseUrl = process.env.NEXT_PUBLIC_SUPABASE_URL;
+const supabaseKey = process.env.NEXT_PUBLIC_SUPABASE_PUBLISHABLE_KEY;
+
+export default function useClerkSupabaseClient() {
+  const { session } = useSession();
+
+  return React.useMemo(() => {
+    if (!supabaseUrl || !supabaseKey) {
+      throw new Error('Missing Supabase environment variables');
+    }
+
+    return createClient<Database>(supabaseUrl, supabaseKey, {
+      accessToken: async () => {
+        return (await session?.getToken()) ?? null;
+      },
+    });
+  }, [session]);
+}

--- a/src/lib/utils/create-supabase-admin-client.ts
+++ b/src/lib/utils/create-supabase-admin-client.ts
@@ -1,0 +1,18 @@
+import { createClient } from '@supabase/supabase-js';
+
+import type { Database } from '@db-types';
+
+const supabaseUrl = process.env.NEXT_PUBLIC_SUPABASE_URL;
+const supabaseSecretKey = process.env.SUPABASE_SECRET_KEY;
+
+export default function createSupabaseAdminClient() {
+  if (!supabaseUrl || !supabaseSecretKey) {
+    throw new Error('Missing Supabase environment variables');
+  }
+
+  return createClient<Database>(supabaseUrl, supabaseSecretKey, {
+    auth: {
+      persistSession: false,
+    },
+  });
+}

--- a/src/lib/utils/remove-storage-prefix.ts
+++ b/src/lib/utils/remove-storage-prefix.ts
@@ -1,3 +1,4 @@
+import * as Sentry from '@sentry/nextjs';
 import type { SupabaseClient } from '@supabase/supabase-js';
 
 import type { Database } from '@db-types';
@@ -52,29 +53,9 @@ export default async function removeStoragePrefix(client: SupabaseClient<Databas
         throw error;
       }
     }
-import * as Sentry from '`@sentry/nextjs`';
-
-const IMAGES_BUCKET = 'images';
-const PAGE_SIZE = 100;
-
-async function listAllFilePaths(client: SupabaseClient<Database>, prefix: string): Promise<string[]> {
-  // ...
-}
-
-export default async function removeStoragePrefix(client: SupabaseClient<Database>, prefix: string) {
-  try {
-    const paths = await listAllFilePaths(client, prefix);
-
-    for (let i = 0; i < paths.length; i += PAGE_SIZE) {
-      const { error } = await client.storage.from(IMAGES_BUCKET).remove(paths.slice(i, i + PAGE_SIZE));
-
-      if (error) {
-        throw error;
-      }
-    }
   } catch (error) {
+    Sentry.captureException(error);
     console.error(`Error removing storage prefix "${prefix}": `, error);
     Sentry.captureException(error, { tags: { prefix } });
   }
-}
 }

--- a/src/lib/utils/remove-storage-prefix.ts
+++ b/src/lib/utils/remove-storage-prefix.ts
@@ -1,0 +1,58 @@
+import type { SupabaseClient } from '@supabase/supabase-js';
+
+import type { Database } from '@db-types';
+
+const IMAGES_BUCKET = 'images';
+const PAGE_SIZE = 100;
+
+async function listAllFilePaths(client: SupabaseClient<Database>, prefix: string): Promise<string[]> {
+  const paths: string[] = [];
+  let offset = 0;
+
+  while (true) {
+    const { data, error } = await client.storage.from(IMAGES_BUCKET).list(prefix, {
+      limit: PAGE_SIZE,
+      offset,
+    });
+
+    if (error) {
+      throw error;
+    }
+
+    if (!data || data.length === 0) {
+      break;
+    }
+
+    for (const item of data) {
+      if (item.id === null) {
+        paths.push(...(await listAllFilePaths(client, `${prefix}/${item.name}`)));
+      } else {
+        paths.push(`${prefix}/${item.name}`);
+      }
+    }
+
+    if (data.length < PAGE_SIZE) {
+      break;
+    }
+
+    offset += PAGE_SIZE;
+  }
+
+  return paths;
+}
+
+export default async function removeStoragePrefix(client: SupabaseClient<Database>, prefix: string) {
+  try {
+    const paths = await listAllFilePaths(client, prefix);
+
+    for (let i = 0; i < paths.length; i += PAGE_SIZE) {
+      const { error } = await client.storage.from(IMAGES_BUCKET).remove(paths.slice(i, i + PAGE_SIZE));
+
+      if (error) {
+        throw error;
+      }
+    }
+  } catch (error) {
+    console.error(`Error removing storage prefix "${prefix}": `, error);
+  }
+}

--- a/src/lib/utils/remove-storage-prefix.ts
+++ b/src/lib/utils/remove-storage-prefix.ts
@@ -52,7 +52,29 @@ export default async function removeStoragePrefix(client: SupabaseClient<Databas
         throw error;
       }
     }
+import * as Sentry from '`@sentry/nextjs`';
+
+const IMAGES_BUCKET = 'images';
+const PAGE_SIZE = 100;
+
+async function listAllFilePaths(client: SupabaseClient<Database>, prefix: string): Promise<string[]> {
+  // ...
+}
+
+export default async function removeStoragePrefix(client: SupabaseClient<Database>, prefix: string) {
+  try {
+    const paths = await listAllFilePaths(client, prefix);
+
+    for (let i = 0; i < paths.length; i += PAGE_SIZE) {
+      const { error } = await client.storage.from(IMAGES_BUCKET).remove(paths.slice(i, i + PAGE_SIZE));
+
+      if (error) {
+        throw error;
+      }
+    }
   } catch (error) {
     console.error(`Error removing storage prefix "${prefix}": `, error);
+    Sentry.captureException(error, { tags: { prefix } });
   }
+}
 }

--- a/supabase/config.toml
+++ b/supabase/config.toml
@@ -109,12 +109,10 @@ file_size_limit = "50MiB"
 # [storage.image_transformation]
 # enabled = true
 
-# Uncomment to configure local storage buckets
-# [storage.buckets.images]
-# public = false
-# file_size_limit = "50MiB"
-# allowed_mime_types = ["image/png", "image/jpeg"]
-# objects_path = "./images"
+[storage.buckets.images]
+public = true
+file_size_limit = "10MiB"
+allowed_mime_types = ["image/png", "image/jpeg", "image/gif", "image/webp"]
 
 [auth]
 enabled = true

--- a/supabase/migrations/20260710204435_create_images_bucket_and_policies.sql
+++ b/supabase/migrations/20260710204435_create_images_bucket_and_policies.sql
@@ -1,0 +1,43 @@
+-- Images Storage Bucket and RLS Policies
+
+INSERT INTO "storage"."buckets" ("id", "name", "public", "file_size_limit", "allowed_mime_types")
+VALUES (
+    'images', -- noqa: CV10
+    'images', -- noqa: CV10
+    TRUE,
+    10485760,
+    ARRAY['image/png', 'image/jpeg', 'image/gif', 'image/webp'] -- noqa: CV10
+)
+ON CONFLICT ("id") DO UPDATE SET
+    "public" = "excluded"."public",
+    "file_size_limit" = "excluded"."file_size_limit",
+    "allowed_mime_types" = "excluded"."allowed_mime_types";
+
+CREATE POLICY "Users can view their own images"
+ON "storage"."objects"
+FOR SELECT
+TO "authenticated"
+USING (
+    "bucket_id" = 'images' -- noqa: CV10
+    AND ("storage"."foldername"("name"))[1] = (SELECT "auth"."jwt"() ->> 'sub') -- noqa: CV10
+);
+
+CREATE POLICY "Users can upload their own images"
+ON "storage"."objects"
+AS PERMISSIVE
+FOR INSERT
+TO "authenticated"
+WITH CHECK (
+    "bucket_id" = 'images' -- noqa: CV10
+    AND ("storage"."foldername"("name"))[1] = (SELECT "auth"."jwt"() ->> 'sub') -- noqa: CV10
+);
+
+CREATE POLICY "Users can delete their own images"
+ON "storage"."objects"
+AS PERMISSIVE
+FOR DELETE
+TO "authenticated"
+USING (
+    "bucket_id" = 'images' -- noqa: CV10
+    AND ("storage"."foldername"("name"))[1] = (SELECT "auth"."jwt"() ->> 'sub') -- noqa: CV10
+);


### PR DESCRIPTION
## Description

Adds image insertion to the editor via URL or direct upload to Supabase Storage. Includes an image resizer component, RLS policies for the images bucket, storage cleanup on document/folder removal, and a Clerk webhook handler for account deletion cleanup.

[skip relative-ci]

## Type of Change

- [ ] Bug fix
- [x] New feature
- [ ] Documentation update
- [ ] Refactoring
- [ ] Performance improvement
- [ ] Test addition or update
- [ ] Build process or tooling change
- [ ] Code style or formatting change
- [ ] Other (please describe)

[//]: # 'Uncomment the following lines if your change is related to an issue'
[//]: # '## Related Issues (if any)'
[//]: #
[//]: # 'Fixes #(issue number)'

## Checklist

- [x] My code follows the project's style guidelines
- [x] I've tested my changes locally
- [ ] I've updated documentation if needed


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Insert images into documents by pasting a URL or uploading GIF, JPEG, PNG, or WebP files up to 10 MB.
  * Add alternative text to images and resize them directly within the editor.
  * Images are stored securely and displayed with improved selection and loading behavior.
* **Bug Fixes**
  * Deleting documents or folders now also removes their associated stored images.
  * Account deletion cleanup now removes related documents, folders, and stored files.
* **Configuration**
  * Added setup requirements for image storage and Clerk webhook processing.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->